### PR TITLE
Update Claude Desktop install steps for v1.152

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ codex plugin add linkedin-skills@linkedin-skills
 ### Claude Desktop (Mac / Windows)
 
 1. Open Claude Desktop
-2. Open **Settings** (gear icon)
-3. Go to **Skills**
-4. Click **Add from GitHub**
-5. Paste: `sergebulaev/linkedin-skills`
+2. Click **Customize**
+3. Click the **+** next to **Personal plugins** → **Create plugin** → **Add marketplace**
+4. Choose **Add from a repository** and paste: `sergebulaev/linkedin-skills`
+5. Install the plugin
 6. Done. Start a new conversation and ask Claude to write a LinkedIn post.
 
 ### OpenClaw


### PR DESCRIPTION
The settings > skills screen and import from GitHub feature has moved. It is now located in the Customize > Plugins screen


<img width="1501" height="681" alt="image" src="https://github.com/user-attachments/assets/10eb8c7f-711a-40ab-a9a6-93576e9699f5" />
