### PR TITLE
Add 2026 nuance: templated bait detection vs. genuine prompts; F6 comment-gate gray-zone status

### DIFF
--- a/references/algorithm-heuristics.md
+++ b/references/algorithm-heuristics.md
@@ -156,6 +156,13 @@ Triggers for suppression:
 
 Observed real consequence: one creator dropped from 8,500 to 340 impressions overnight after pod detection.
 
+**Templated bait vs. genuine prompts (2026 consensus):**
+- LinkedIn's official enforcement targets **automation and coordinated pods** (VP Product Gyanda Sachdeva, via Social Media Today), plus 2025 per-account comment rate limits — not organic CTAs per se
+- Van der Blom's Algorithm Insights 2026 (~1.3M posts): **semantic quality and depth of comment threads now outweigh raw count** — three distinct professional perspectives beat ten "great post!" replies
+- Keyword-only templated triggers ("Comment YES", "Like for Part 2", bare "What do you think?") are broadly reported as detectable and down-ranked; a **specific, experience-anchored question** ("What's the worst rollback you had to do in production?") is the safe replacement
+- Curiosity-gap openers are **not** bait: the "see more" click remains one of the strongest positive signals — earning attention with the hook is distinct from asking for a reflexive action
+- Circulating penalty percentages (e.g., "-60% for bait") propagate blog-to-blog without traceable primary studies — treat as directional
+
 **Recovery times:**
 - From pod detection: **6-8 weeks**
 - Already-credible account cold start: ~1 week

--- a/references/hook-formulas.md
+++ b/references/hook-formulas.md
@@ -195,6 +195,8 @@ Comment "{keyword}" below + connect with me and I'll send the bundle.
 
 **Warning:** This is engagement bait. Ship only when the weekly goal is list-building, not thought leadership. LinkedIn suppresses pure "comment X" posts.
 
+**2026 status — gray zone, format-sensitive:** comment-gates still outperform link-in-body posts (they keep interaction on-platform), but keyword-only templated triggers are increasingly detected and suppressed. If shipped, the gate must sit inside a genuinely substantive post: real authority numbers, a named specific bundle, personalized framing — never a bare "comment X" line. For expert/technical audiences (developers, CTOs) the trust cost usually exceeds the reach gain; prefer F1-F5 there. Evidence: van der Blom Algorithm Insights 2026; LinkedIn's 2025 comment rate-limit policy; Social Media Today coverage of anti-pod enforcement.
+
 ---
 
 ## F7 — Odd-Precision Money Ledger


### PR DESCRIPTION
## What

Two reference updates based on cross-checked mid-2026 research (LinkedIn official statements, van der Blom's Algorithm Insights Report 2026, Social Media Today coverage):

### `references/algorithm-heuristics.md`
New **"Templated bait vs. genuine prompts (2026 consensus)"** block in the pod-detection section:
- Official enforcement targets **automation and coordinated pods** (VP Product Gyanda Sachdeva) + 2025 per-account comment rate limits — not organic CTAs per se
- Van der Blom 2026 (~1.3M posts): comment **semantic depth now outweighs raw count**
- Keyword-only templated triggers ("Comment YES", bare "What do you think?") are detectable/down-ranked; specific experience-anchored questions are the safe replacement
- Curiosity-gap openers are explicitly **not** bait (see-more click remains a top positive signal)
- Caveat: circulating penalty percentages propagate blog-to-blog without traceable primary studies

### `references/hook-formulas.md`
F6 Comment-Gate gets a **2026 status** paragraph: format-sensitive gray zone — still beats link-in-body posts, but bare templated triggers are suppressed; requires a genuinely substantive surrounding post; trust cost usually exceeds reach gain for developer/CTO audiences (prefer F1–F5 there).

## Why

The existing F6 warning says LinkedIn "suppresses pure comment-X posts" — true, but users need the finer distinction the 2026 evidence supports: *phrasing pattern* vs. *mechanism*, and audience-dependent trust cost. Sources: Social Media Today anti-pod coverage, van der Blom Algorithm Insights 2026, Forbes (Jodie Cook, Mar 2026), ConnectSafely 2026 analyses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)