### PR TITLE
Fix front matter and sub-skill references so the skills load

### DIFF
--- a/.codex-marketplace/linkedin-skills/skills/linkedin-content-planner/references/pillars-framework.md
+++ b/.codex-marketplace/linkedin-skills/skills/linkedin-content-planner/references/pillars-framework.md
@@ -171,7 +171,7 @@ Different audiences need different pillar distributions. Start from the default 
 ### Founders (when wearing the exec hat)
 Same as Executives, but with leeway to include more behind-the-scenes content if shipping in public.
 
-For a dedicated founder plan, use the **founders-edition pillar set** (Conviction / Building in public / The math / Proof) and the 10 founder angles in `../../references/founder-topics.md` instead of the generic Authority / Narrative / Community / Product mix. It is built for founders raising, hiring, and landing design partners, where a narrow high-trust audience matters more than reach.
+For a dedicated founder plan, use the **founders-edition pillar set** (Conviction / Building in public / The math / Proof) and the 10 founder angles in `../../../references/founder-topics.md` instead of the generic Authority / Narrative / Community / Product mix. It is built for founders raising, hiring, and landing design partners, where a narrow high-trust audience matters more than reach.
 
 ## Recovery / cold-start 5-step protocol
 

--- a/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/SKILL.md
+++ b/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: linkedin-humanizer
-description: 'Scrub AI tells from any text draft OR audit a finished post against the 2026 algorithm heuristic checklist. Tier-based rewriter (forensic / strict / aesthetic / all) plus `--mode audit` for detection-only pass-fail review covering length, hook, CTA, format penalties, AI vocab. Also `--mode profile` builds a reusable Voice and Brand Profile from a few of the user's real posts, so every writing skill drafts in their voice. Sub-tools: emoji-pattern detector, multi-detector spread tester (GPTZero, Originality.ai, ZeroGPT, Sapling, Copyleaks), rule explainer. Triggers on "humanize", "de-AI", "review this draft", "audit before posting", "is this ready", "build my voice profile", "learn my voice".'
+description: >-
+  Scrub AI tells from any text draft OR audit a finished post against the 2026 algorithm heuristic checklist. Tier-based rewriter (forensic / strict / aesthetic / all) plus `--mode audit` for detection-only pass-fail review covering length, hook, CTA, format penalties, AI vocab. Also `--mode profile` builds a reusable Voice and Brand Profile from a few of the user's real posts, so every writing skill drafts in their voice. Sub-tools: emoji-pattern detector, multi-detector spread tester (GPTZero, Originality.ai, ZeroGPT, Sapling, Copyleaks), rule explainer. Triggers on "humanize", "de-AI", "review this draft", "audit before posting", "is this ready", "build my voice profile", "learn my voice".
 ---
 
 # LinkedIn Humanizer V2

--- a/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/sub-skills/illustration.md
+++ b/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/sub-skills/illustration.md
@@ -32,7 +32,7 @@ media. Runs on any agent (Claude Code, Codex, OpenClaw).
    style, palette. Default to a clean, non-literal, professional editorial look
    unless the Voice & Brand Profile §6 sets a `Visual style default`. Do NOT try
    to render the post's words inside the art (see overlay below).
-3. **Apply brand overlay (if profile has it).** Read `../../references/voice-profile.md`
+3. **Apply brand overlay (if profile has it).** Read `../../../references/voice-profile.md`
    §6 Brand assets. If a handle, brand color, or logo is set, pass an `overlay`
    so the text/logo is composited pixel-exact (crisp even on a cheap model):
    ```python

--- a/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/sub-skills/voice-profile.md
+++ b/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/sub-skills/voice-profile.md
@@ -1,6 +1,6 @@
 # Sub-skill: Build / update the Voice & Brand Profile
 
-Builds or refreshes `../../references/voice-profile.md` so every writing skill in
+Builds or refreshes `../../../references/voice-profile.md` so every writing skill in
 this bundle drafts in the user's real voice instead of a generic "human" voice.
 Runs on any agent (Claude Code, Codex, OpenClaw): the core path needs only the
 user's own writing pasted in. Apify is an optional accelerator, never required.
@@ -33,7 +33,7 @@ user's own writing pasted in. Apify is an optional accelerator, never required.
 3. **Infer niche, ICP, and pillars** from the sample topics; confirm with the user
    rather than guessing.
 4. **Capture hard rules and CTA/link style** the samples reveal or the user states.
-5. **Write `../../references/voice-profile.md`**: fill sections 1-5, copy the 2-4
+5. **Write `../../../references/voice-profile.md`**: fill sections 1-5, copy the 2-4
    strongest lines verbatim into "Signature examples", and set the Status block to
    `filled: yes`, `source: <pasted|apify|manual>`, `updated: <today's date>`.
 6. **Show the user the filled profile for approval** before saving, and tell them

--- a/.codex-marketplace/linkedin-skills/skills/linkedin-repurposer/SKILL.md
+++ b/.codex-marketplace/linkedin-skills/skills/linkedin-repurposer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: linkedin-repurposer
-description: Repurpose existing content into a native LinkedIn post. Take a tweet, thread, YouTube video, blog, or newsletter and rebuild it for LinkedIn: re-hook before the fold, expand to the 900 to 1300 char sweet spot, add whitespace and a CTA, move links to the first comment, run the humanizer, publish via Publora on approval. Not for writing from scratch (use linkedin-post-writer), not for auditing a draft (use linkedin-humanizer --mode audit).
+description: >-
+  Repurpose existing content into a native LinkedIn post. Take a tweet, thread, YouTube video, blog, or newsletter and rebuild it for LinkedIn: re-hook before the fold, expand to the 900 to 1300 char sweet spot, add whitespace and a CTA, move links to the first comment, run the humanizer, publish via Publora on approval. Not for writing from scratch (use linkedin-post-writer), not for auditing a draft (use linkedin-humanizer --mode audit).
 ---
 
 # LinkedIn Repurposer

--- a/skills/linkedin-content-planner/references/pillars-framework.md
+++ b/skills/linkedin-content-planner/references/pillars-framework.md
@@ -171,7 +171,7 @@ Different audiences need different pillar distributions. Start from the default 
 ### Founders (when wearing the exec hat)
 Same as Executives, but with leeway to include more behind-the-scenes content if shipping in public.
 
-For a dedicated founder plan, use the **founders-edition pillar set** (Conviction / Building in public / The math / Proof) and the 10 founder angles in `../../references/founder-topics.md` instead of the generic Authority / Narrative / Community / Product mix. It is built for founders raising, hiring, and landing design partners, where a narrow high-trust audience matters more than reach.
+For a dedicated founder plan, use the **founders-edition pillar set** (Conviction / Building in public / The math / Proof) and the 10 founder angles in `../../../references/founder-topics.md` instead of the generic Authority / Narrative / Community / Product mix. It is built for founders raising, hiring, and landing design partners, where a narrow high-trust audience matters more than reach.
 
 ## Recovery / cold-start 5-step protocol
 

--- a/skills/linkedin-humanizer/SKILL.md
+++ b/skills/linkedin-humanizer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: linkedin-humanizer
-description: 'Scrub AI tells from any text draft OR audit a finished post against the 2026 algorithm heuristic checklist. Tier-based rewriter (forensic / strict / aesthetic / all) plus `--mode audit` for detection-only pass-fail review covering length, hook, CTA, format penalties, AI vocab. Also `--mode profile` builds a reusable Voice and Brand Profile from a few of the user's real posts, so every writing skill drafts in their voice. Sub-tools: emoji-pattern detector, multi-detector spread tester (GPTZero, Originality.ai, ZeroGPT, Sapling, Copyleaks), rule explainer. Triggers on "humanize", "de-AI", "review this draft", "audit before posting", "is this ready", "build my voice profile", "learn my voice".'
+description: >-
+  Scrub AI tells from any text draft OR audit a finished post against the 2026 algorithm heuristic checklist. Tier-based rewriter (forensic / strict / aesthetic / all) plus `--mode audit` for detection-only pass-fail review covering length, hook, CTA, format penalties, AI vocab. Also `--mode profile` builds a reusable Voice and Brand Profile from a few of the user's real posts, so every writing skill drafts in their voice. Sub-tools: emoji-pattern detector, multi-detector spread tester (GPTZero, Originality.ai, ZeroGPT, Sapling, Copyleaks), rule explainer. Triggers on "humanize", "de-AI", "review this draft", "audit before posting", "is this ready", "build my voice profile", "learn my voice".
 ---
 
 # LinkedIn Humanizer V2

--- a/skills/linkedin-humanizer/sub-skills/illustration.md
+++ b/skills/linkedin-humanizer/sub-skills/illustration.md
@@ -32,7 +32,7 @@ media. Runs on any agent (Claude Code, Codex, OpenClaw).
    style, palette. Default to a clean, non-literal, professional editorial look
    unless the Voice & Brand Profile §6 sets a `Visual style default`. Do NOT try
    to render the post's words inside the art (see overlay below).
-3. **Apply brand overlay (if profile has it).** Read `../../references/voice-profile.md`
+3. **Apply brand overlay (if profile has it).** Read `../../../references/voice-profile.md`
    §6 Brand assets. If a handle, brand color, or logo is set, pass an `overlay`
    so the text/logo is composited pixel-exact (crisp even on a cheap model):
    ```python

--- a/skills/linkedin-humanizer/sub-skills/voice-profile.md
+++ b/skills/linkedin-humanizer/sub-skills/voice-profile.md
@@ -1,6 +1,6 @@
 # Sub-skill: Build / update the Voice & Brand Profile
 
-Builds or refreshes `../../references/voice-profile.md` so every writing skill in
+Builds or refreshes `../../../references/voice-profile.md` so every writing skill in
 this bundle drafts in the user's real voice instead of a generic "human" voice.
 Runs on any agent (Claude Code, Codex, OpenClaw): the core path needs only the
 user's own writing pasted in. Apify is an optional accelerator, never required.
@@ -33,7 +33,7 @@ user's own writing pasted in. Apify is an optional accelerator, never required.
 3. **Infer niche, ICP, and pillars** from the sample topics; confirm with the user
    rather than guessing.
 4. **Capture hard rules and CTA/link style** the samples reveal or the user states.
-5. **Write `../../references/voice-profile.md`**: fill sections 1-5, copy the 2-4
+5. **Write `../../../references/voice-profile.md`**: fill sections 1-5, copy the 2-4
    strongest lines verbatim into "Signature examples", and set the Status block to
    `filled: yes`, `source: <pasted|apify|manual>`, `updated: <today's date>`.
 6. **Show the user the filled profile for approval** before saving, and tell them

--- a/skills/linkedin-repurposer/SKILL.md
+++ b/skills/linkedin-repurposer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: linkedin-repurposer
-description: Repurpose existing content into a native LinkedIn post. Take a tweet, thread, YouTube video, blog, or newsletter and rebuild it for LinkedIn: re-hook before the fold, expand to the 900 to 1300 char sweet spot, add whitespace and a CTA, move links to the first comment, run the humanizer, publish via Publora on approval. Not for writing from scratch (use linkedin-post-writer), not for auditing a draft (use linkedin-humanizer --mode audit).
+description: >-
+  Repurpose existing content into a native LinkedIn post. Take a tweet, thread, YouTube video, blog, or newsletter and rebuild it for LinkedIn: re-hook before the fold, expand to the 900 to 1300 char sweet spot, add whitespace and a CTA, move links to the first comment, run the humanizer, publish via Publora on approval. Not for writing from scratch (use linkedin-post-writer), not for auditing a draft (use linkedin-humanizer --mode audit).
 ---
 
 # LinkedIn Repurposer


### PR DESCRIPTION
Two things that stop this package working after a fresh install. Both are
verified against `main` as of today, and neither changes any wording.

## 1. Front matter that does not parse

Claude Code reads the front matter of each `SKILL.md` as YAML. In several of
them it raises, and the skill then never appears in a session - no error
message, nothing missing from the plugin list, just a skill that is not there.

Two causes:

- an unquoted scalar containing `": "`, which YAML reads as the start of a
  nested mapping
- a single-quoted scalar with an unescaped apostrophe, which closes the string
  early

Both fixed by moving `description` to a folded block scalar (`>-`), which needs
no escaping at all. Each description was compared character for character after
the edit, so the text is byte-identical.

Checked with `yaml.safe_load` over every `SKILL.md` in the repo: they all parse
now, and each has a `name` and a `description`.

## 2. Sub-skill references one level short

A file under `skills/<name>/sub-skills/` or `skills/<name>/references/` sits one
directory deeper than `SKILL.md`, so the shared `references/` at the repo root
is `../../../references/` from there rather than `../../`. Every one of these was
short by one level and did not resolve.

Only paths that fail today and start resolving with one more `../` were touched.
Correct ones were left alone, and so was `../../references/X.md` in `CLAUDE.md`
and `AGENTS.md` - that one is a placeholder in prose, not a link.

The `.codex-marketplace/` copies carry the same files and are fixed alongside,
so the two trees do not drift.