### PR TITLE
fix(lib): lazy-load HTTP clients so Tier 0 works without requests

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -6,9 +6,6 @@ utilities (e.g., `build_parent_comment_urn`, `signup_nudge`,
 re-exported here.
 """
 from .url_parser import parse_linkedin_url
-from .publora_client import PubloraClient, PubloraError
-from .apify_client import ApifyClient, ApifyError
-from .pixfaro_client import PixfaroClient, PixfaroError
 from .approval import render_approval_card
 from .backend_selector import (
     active_backend,
@@ -22,6 +19,30 @@ from .backend_selector import (
     refine,
     available_models,
 )
+
+# The three HTTP clients import `requests`, which manual-tier users are not
+# required to install. Load them on first attribute access (PEP 562) so
+# `import lib` keeps working with no dependencies at all.
+_LAZY_CLIENTS = {
+    "PubloraClient": "publora_client",
+    "PubloraError": "publora_client",
+    "ApifyClient": "apify_client",
+    "ApifyError": "apify_client",
+    "PixfaroClient": "pixfaro_client",
+    "PixfaroError": "pixfaro_client",
+}
+
+
+def __getattr__(name: str):
+    module = _LAZY_CLIENTS.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(f".{module}", __name__), name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "parse_linkedin_url",


### PR DESCRIPTION
## Problem

`import lib` fails with `ModuleNotFoundError: No module named 'requests'` on any machine that does not have `requests` installed, including Tier 0 (manual) users who never make a network call.

`lib/__init__.py` eagerly imports `PubloraClient`, `ApifyClient` and `PixfaroClient`, and all three import `requests` at module level. Since `lib/__init__.py` runs on any `import lib`, the dependency is effectively mandatory for every tier.

This defeats the design already documented in `lib/backend_selector.py:172`:

```python
# Local import so manual-tier users never need `requests` installed.
from .publora_client import PubloraClient
```

That local import is correct, but the package `__init__` pulls the same module in first, so it never gets the chance to help.

Repro on a clean interpreter with no `requests`:

```
>>> import lib
ModuleNotFoundError: No module named 'requests'
```

This is the documented zero-setup path (README "Tier 0 - Draft only (default, no setup)"), so it is the first thing a new user hits.

## Fix

Load the three HTTP clients on first attribute access via a module-level `__getattr__` (PEP 562). `url_parser`, `approval` and `backend_selector` have no third-party imports and stay eager.

`__all__` and the public surface are unchanged. Resolved attributes are cached into `globals()`, so repeat access costs nothing after the first hit and there is no steady-state overhead.

## Verification

Without `requests` installed:

| Check | Before | After |
|---|---|---|
| `import lib` | ModuleNotFoundError | OK |
| `lib.active_backend()` | n/a | `manual` |
| `lib.publish(kind="post", ...)` | n/a | `manual`, no network call |
| `lib.parse_linkedin_url(...)` | n/a | OK |
| `lib.render_approval_card(...)` | n/a | OK |

With `requests` installed (clean venv): all three clients resolve to the real classes, and `from lib import *` returns all 18 names in `__all__`.

Error paths stay honest. `lib.PubloraClient` without `requests` raises the real `ModuleNotFoundError: No module named 'requests'` rather than masking it, and an unknown name still raises `AttributeError`.

## Notes

No dependency, version or behaviour changes. Single file, +24 / -3.