### PR TITLE
Fix invalid YAML frontmatter that stops linkedin-humanizer from loading

### DIFF
--- a/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/SKILL.md
+++ b/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linkedin-humanizer
-description: 'Scrub AI tells from any text draft OR audit a finished post against the 2026 algorithm heuristic checklist. Tier-based rewriter (forensic / strict / aesthetic / all) plus `--mode audit` for detection-only pass-fail review covering length, hook, CTA, format penalties, AI vocab. Also `--mode profile` builds a reusable Voice and Brand Profile from a few of the user's real posts, so every writing skill drafts in their voice. Sub-tools: emoji-pattern detector, multi-detector spread tester (GPTZero, Originality.ai, ZeroGPT, Sapling, Copyleaks), rule explainer. Triggers on "humanize", "de-AI", "review this draft", "audit before posting", "is this ready", "build my voice profile", "learn my voice".'
+description: 'Scrub AI tells from any text draft OR audit a finished post against the 2026 algorithm heuristic checklist. Tier-based rewriter (forensic / strict / aesthetic / all) plus `--mode audit` for detection-only pass-fail review covering length, hook, CTA, format penalties, AI vocab. Also `--mode profile` builds a reusable Voice and Brand Profile from a few of the user''s real posts, so every writing skill drafts in their voice. Sub-tools: emoji-pattern detector, multi-detector spread tester (GPTZero, Originality.ai, ZeroGPT, Sapling, Copyleaks), rule explainer. Triggers on "humanize", "de-AI", "review this draft", "audit before posting", "is this ready", "build my voice profile", "learn my voice".'
 ---
 
 # LinkedIn Humanizer V2

--- a/.codex-marketplace/linkedin-skills/skills/linkedin-repurposer/SKILL.md
+++ b/.codex-marketplace/linkedin-skills/skills/linkedin-repurposer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linkedin-repurposer
-description: Repurpose existing content into a native LinkedIn post. Take a tweet, thread, YouTube video, blog, or newsletter and rebuild it for LinkedIn: re-hook before the fold, expand to the 900 to 1300 char sweet spot, add whitespace and a CTA, move links to the first comment, run the humanizer, publish via Publora on approval. Not for writing from scratch (use linkedin-post-writer), not for auditing a draft (use linkedin-humanizer --mode audit).
+description: 'Repurpose existing content into a native LinkedIn post. Take a tweet, thread, YouTube video, blog, or newsletter and rebuild it for LinkedIn: re-hook before the fold, expand to the 900 to 1300 char sweet spot, add whitespace and a CTA, move links to the first comment, run the humanizer, publish via Publora on approval. Not for writing from scratch (use linkedin-post-writer), not for auditing a draft (use linkedin-humanizer --mode audit).'
 ---
 
 # LinkedIn Repurposer

--- a/skills/linkedin-humanizer/SKILL.md
+++ b/skills/linkedin-humanizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linkedin-humanizer
-description: 'Scrub AI tells from any text draft OR audit a finished post against the 2026 algorithm heuristic checklist. Tier-based rewriter (forensic / strict / aesthetic / all) plus `--mode audit` for detection-only pass-fail review covering length, hook, CTA, format penalties, AI vocab. Also `--mode profile` builds a reusable Voice and Brand Profile from a few of the user's real posts, so every writing skill drafts in their voice. Sub-tools: emoji-pattern detector, multi-detector spread tester (GPTZero, Originality.ai, ZeroGPT, Sapling, Copyleaks), rule explainer. Triggers on "humanize", "de-AI", "review this draft", "audit before posting", "is this ready", "build my voice profile", "learn my voice".'
+description: 'Scrub AI tells from any text draft OR audit a finished post against the 2026 algorithm heuristic checklist. Tier-based rewriter (forensic / strict / aesthetic / all) plus `--mode audit` for detection-only pass-fail review covering length, hook, CTA, format penalties, AI vocab. Also `--mode profile` builds a reusable Voice and Brand Profile from a few of the user''s real posts, so every writing skill drafts in their voice. Sub-tools: emoji-pattern detector, multi-detector spread tester (GPTZero, Originality.ai, ZeroGPT, Sapling, Copyleaks), rule explainer. Triggers on "humanize", "de-AI", "review this draft", "audit before posting", "is this ready", "build my voice profile", "learn my voice".'
 ---
 
 # LinkedIn Humanizer V2

--- a/skills/linkedin-repurposer/SKILL.md
+++ b/skills/linkedin-repurposer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linkedin-repurposer
-description: Repurpose existing content into a native LinkedIn post. Take a tweet, thread, YouTube video, blog, or newsletter and rebuild it for LinkedIn: re-hook before the fold, expand to the 900 to 1300 char sweet spot, add whitespace and a CTA, move links to the first comment, run the humanizer, publish via Publora on approval. Not for writing from scratch (use linkedin-post-writer), not for auditing a draft (use linkedin-humanizer --mode audit).
+description: 'Repurpose existing content into a native LinkedIn post. Take a tweet, thread, YouTube video, blog, or newsletter and rebuild it for LinkedIn: re-hook before the fold, expand to the 900 to 1300 char sweet spot, add whitespace and a CTA, move links to the first comment, run the humanizer, publish via Publora on approval. Not for writing from scratch (use linkedin-post-writer), not for auditing a draft (use linkedin-humanizer --mode audit).'
 ---
 
 # LinkedIn Repurposer


### PR DESCRIPTION
## What's wrong

`linkedin-humanizer` does not load in Claude Code. It never appears in the skill list, with no error — installing the plugin gives you 10 of the 11 skills and nothing says why.

The cause is in its frontmatter:

```yaml
description: 'Scrub AI tells ... from a few of the user's real posts, so every ...'
```

Inside a single-quoted YAML scalar a literal apostrophe must be doubled (`''`). As written, the scalar terminates at `user'` and the rest of the line is a parse error, so the frontmatter is invalid and the skill gets dropped silently.

```
yaml.parser.ParserError: while parsing a block mapping
expected <block end>, but found '<scalar>'
```

## Also fixed

`linkedin-repurposer` has the same class of defect — an unquoted scalar containing `for LinkedIn: re-hook`, where the colon-space reads as a nested mapping key:

```
yaml.scanner.ScannerError: mapping values are not allowed here
```

Claude Code's frontmatter parser is lenient enough to tolerate this one, so the skill does load today. But strict YAML rejects it, which makes it a latent break for Codex and any other consumer of these files. Since it's the identical bug class and a one-character-per-file fix, I included it — happy to split it out if you'd rather keep the PR to the loading bug alone.

## The change

Quoting only. Both descriptions round-trip to exactly the bytes that were there before — no wording changed:

| Skill | Before | After |
|---|---|---|
| `linkedin-humanizer` | `the user's real posts` | `the user''s real posts` |
| `linkedin-repurposer` | unquoted scalar | wrapped in `'...'` |

The `.codex-marketplace/` mirror was regenerated with `scripts/sync_codex_marketplace.py` rather than edited by hand.

## Verification

All 24 `SKILL.md` files in the repo now parse under `yaml.safe_load` (was 20 of 24). Verified the two edited descriptions deserialize to strings identical to the originals.

## Suggestion, not included here

A frontmatter parse check in `.github/workflows/` would catch this class of bug before release — it's invisible in review because a malformed skill looks exactly like a skill that isn't there. Glad to send that as a separate PR if it'd be useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)