### PR TITLE
v1.0.27: add scripts/schedule_post.py for scheduled LinkedIn posting

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "linkedin-skills",
       "source": "./",
       "description": "Bundle of 11 LinkedIn marketing skills for Claude Code and Codex with verified 2026 hook formulas, comment + reply templates that earn author replies, a unified humanizer (rewrite + `--mode audit` pre-publish check, plus bundled emoji-detector, detector-spread tester, rule-explainer sub-tools), profile rewriter, content planner, employee advocacy playbook, thread monitor (warm-reply window author-reply tracking), and engager analytics (likers + commenters ICP segmentation).",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "author": {
         "name": "Serge Bulaev",
         "url": "https://github.com/sergebulaev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.codex-marketplace/linkedin-skills/.codex-plugin/plugin.json
+++ b/.codex-marketplace/linkedin-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.codex-marketplace/linkedin-skills/scripts/schedule_post.py
+++ b/.codex-marketplace/linkedin-skills/scripts/schedule_post.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""CLI: schedule an approved LinkedIn post via Publora at 10:00 local time.
+
+Usage:
+    python scripts/schedule_post.py --file draft.txt --angle <slug> [--source URL ...] [--dry-run]
+    python scripts/schedule_post.py --selftest
+
+Schedule rule: today at 10:00 local. If it is already past 10:00, now + 5 min
+(Publora treats a missing scheduledTime as "save as draft", so there is no
+true "post immediately" call, so the nearest thing is a schedule a few minutes out).
+
+Every successful schedule appends one JSON line to testing/linkedin-routine-log.jsonl
+so the next run can rotate to a different angle. testing/ is gitignored.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+LOG_PATH = ROOT / "testing" / "linkedin-routine-log.jsonl"
+POST_HOUR = 10
+LEAD_MINUTES = 5
+
+
+def slot(now: datetime) -> datetime:
+    """Today's 10:00 slot in `now`'s timezone, or now+5min if that has passed."""
+    ten = now.replace(hour=POST_HOUR, minute=0, second=0, microsecond=0)
+    return ten if now < ten else now + timedelta(minutes=LEAD_MINUTES)
+
+
+def selftest() -> int:
+    tz = timezone(timedelta(hours=-6))
+    early = datetime(2026, 9, 7, 8, 30, tzinfo=tz)
+    assert slot(early) == datetime(2026, 9, 7, 10, 0, tzinfo=tz)
+    late = datetime(2026, 9, 7, 14, 20, tzinfo=tz)
+    assert slot(late) == datetime(2026, 9, 7, 14, 25, tzinfo=tz)
+    # 10:00 exactly counts as passed -> nudged forward, never scheduled in the past
+    assert slot(datetime(2026, 9, 7, 10, 0, tzinfo=tz)) > datetime(2026, 9, 7, 10, 0, tzinfo=tz)
+    assert slot(early).astimezone(timezone.utc).isoformat() == "2026-09-07T16:00:00+00:00"
+    print("selftest OK")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--file", help="path to the final post text (UTF-8)")
+    ap.add_argument("--angle", default="", help="sub-topic slug used, for rotation logging")
+    ap.add_argument("--source", action="append", default=[], help="source URL/title (repeatable)")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+    if not args.file:
+        ap.error("--file is required")
+
+    text = Path(args.file).read_text(encoding="utf-8").strip()
+    if not text:
+        print("✗ draft file is empty", file=sys.stderr)
+        return 2
+    if len(text) > 3000:
+        print(f"✗ draft is {len(text)} chars, LinkedIn caps posts at 3000", file=sys.stderr)
+        return 2
+
+    when = slot(datetime.now().astimezone())
+    scheduled_utc = when.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"→ {len(text)} chars, scheduled {when.isoformat()} (UTC {scheduled_utc})")
+
+    if args.dry_run:
+        print("(dry-run, nothing scheduled)")
+        return 0
+
+    from dotenv import load_dotenv
+
+    load_dotenv(ROOT / ".env")
+
+    from lib import active_backend, publish
+
+    backend = active_backend()
+    if backend != "publora":
+        print(f"✗ backend is {backend!r}, expected 'publora'. Check PUBLORA_API_KEY "
+              f"and LINKEDIN_PLATFORM_ID in .env", file=sys.stderr)
+        return 2
+
+    try:
+        resp = publish(
+            "post",
+            text,
+            "https://www.linkedin.com/feed/",
+            scheduled_time=scheduled_utc,
+        )
+    except Exception as e:
+        print(f"✗ publora schedule failed: {e}", file=sys.stderr)
+        return 1
+
+    r = resp or {}
+    post_id = r.get("postGroupId") or r.get("postId") or r.get("id") or json.dumps(r)[:200]
+    entry = {
+        "date": when.date().isoformat(),
+        "angle": args.angle,
+        "sources": args.source,
+        "scheduled_utc": scheduled_utc,
+        "post_id": post_id,
+        "chars": len(text),
+    }
+    LOG_PATH.parent.mkdir(exist_ok=True)
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    print(f"✓ scheduled. publora post id: {post_id}")
+    print(f"  raw response: {json.dumps(resp, ensure_ascii=False)[:400]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/scripts/schedule_post.py
+++ b/scripts/schedule_post.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""CLI: schedule an approved LinkedIn post via Publora at 10:00 local time.
+
+Usage:
+    python scripts/schedule_post.py --file draft.txt --angle <slug> [--source URL ...] [--dry-run]
+    python scripts/schedule_post.py --selftest
+
+Schedule rule: today at 10:00 local. If it is already past 10:00, now + 5 min
+(Publora treats a missing scheduledTime as "save as draft", so there is no
+true "post immediately" call, so the nearest thing is a schedule a few minutes out).
+
+Every successful schedule appends one JSON line to testing/linkedin-routine-log.jsonl
+so the next run can rotate to a different angle. testing/ is gitignored.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+LOG_PATH = ROOT / "testing" / "linkedin-routine-log.jsonl"
+POST_HOUR = 10
+LEAD_MINUTES = 5
+
+
+def slot(now: datetime) -> datetime:
+    """Today's 10:00 slot in `now`'s timezone, or now+5min if that has passed."""
+    ten = now.replace(hour=POST_HOUR, minute=0, second=0, microsecond=0)
+    return ten if now < ten else now + timedelta(minutes=LEAD_MINUTES)
+
+
+def selftest() -> int:
+    tz = timezone(timedelta(hours=-6))
+    early = datetime(2026, 9, 7, 8, 30, tzinfo=tz)
+    assert slot(early) == datetime(2026, 9, 7, 10, 0, tzinfo=tz)
+    late = datetime(2026, 9, 7, 14, 20, tzinfo=tz)
+    assert slot(late) == datetime(2026, 9, 7, 14, 25, tzinfo=tz)
+    # 10:00 exactly counts as passed -> nudged forward, never scheduled in the past
+    assert slot(datetime(2026, 9, 7, 10, 0, tzinfo=tz)) > datetime(2026, 9, 7, 10, 0, tzinfo=tz)
+    assert slot(early).astimezone(timezone.utc).isoformat() == "2026-09-07T16:00:00+00:00"
+    print("selftest OK")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--file", help="path to the final post text (UTF-8)")
+    ap.add_argument("--angle", default="", help="sub-topic slug used, for rotation logging")
+    ap.add_argument("--source", action="append", default=[], help="source URL/title (repeatable)")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+    if not args.file:
+        ap.error("--file is required")
+
+    text = Path(args.file).read_text(encoding="utf-8").strip()
+    if not text:
+        print("✗ draft file is empty", file=sys.stderr)
+        return 2
+    if len(text) > 3000:
+        print(f"✗ draft is {len(text)} chars, LinkedIn caps posts at 3000", file=sys.stderr)
+        return 2
+
+    when = slot(datetime.now().astimezone())
+    scheduled_utc = when.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"→ {len(text)} chars, scheduled {when.isoformat()} (UTC {scheduled_utc})")
+
+    if args.dry_run:
+        print("(dry-run, nothing scheduled)")
+        return 0
+
+    from dotenv import load_dotenv
+
+    load_dotenv(ROOT / ".env")
+
+    from lib import active_backend, publish
+
+    backend = active_backend()
+    if backend != "publora":
+        print(f"✗ backend is {backend!r}, expected 'publora'. Check PUBLORA_API_KEY "
+              f"and LINKEDIN_PLATFORM_ID in .env", file=sys.stderr)
+        return 2
+
+    try:
+        resp = publish(
+            "post",
+            text,
+            "https://www.linkedin.com/feed/",
+            scheduled_time=scheduled_utc,
+        )
+    except Exception as e:
+        print(f"✗ publora schedule failed: {e}", file=sys.stderr)
+        return 1
+
+    r = resp or {}
+    post_id = r.get("postGroupId") or r.get("postId") or r.get("id") or json.dumps(r)[:200]
+    entry = {
+        "date": when.date().isoformat(),
+        "angle": args.angle,
+        "sources": args.source,
+        "scheduled_utc": scheduled_utc,
+        "post_id": post_id,
+        "chars": len(text),
+    }
+    LOG_PATH.parent.mkdir(exist_ok=True)
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    print(f"✓ scheduled. publora post id: {post_id}")
+    print(f"  raw response: {json.dumps(resp, ensure_ascii=False)[:400]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a small CLI that schedules an already-approved post through the existing Publora write layer, so a recurring routine can drive it unattended.

## What it does

`scripts/schedule_post.py --file draft.txt --angle <slug> [--source URL ...]`

- Targets today's 10:00 local slot, falling back to now + 5 minutes when 10:00 has already passed. Publora treats a missing `scheduledTime` as "save as draft", so there is no true post-now call and a few minutes out is the nearest equivalent.
- Reads the returned post id from `postGroupId`, which is the field `POST /create-post` actually returns. Not `postId` or `id`.
- Appends one JSON line per run to `testing/linkedin-routine-log.jsonl` (gitignored) so a scheduled routine can rotate topics instead of repeating an angle.
- Goes through `lib.publish("post", ...)` rather than touching `PubloraClient` directly, per the layer separation rule in CLAUDE.md.

## Guard rails

- Refuses to run when `active_backend()` is not `publora`, with a message pointing at the missing env var.
- Rejects an empty draft, and drafts over LinkedIn's 3000 char cap.
- `--dry-run` prints the computed slot without publishing.
- `--selftest` asserts the slot math, including that exactly 10:00 counts as passed so a post is never scheduled into the past.

## Verification

`--selftest` passes, `--dry-run` passes, and one real post was scheduled end to end against the live Publora API (`postGroupId` returned and logged).

Skill count unchanged at 11. Codex marketplace package synced via `scripts/sync_codex_marketplace.py`. Patch bump to 1.0.27 across `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `.codex-plugin/plugin.json`.

Note on the version: the bump is included here to match repo convention, but if a 1.0.27 ships from another branch first this will need a rebase onto the next free patch number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)