### PR TITLE
fix(lib): auto-load .env for credentials and fix voice-profile reference path

### DIFF
--- a/.codex-marketplace/linkedin-skills/lib/__init__.py
+++ b/.codex-marketplace/linkedin-skills/lib/__init__.py
@@ -5,8 +5,12 @@ utilities (e.g., `build_parent_comment_urn`, `signup_nudge`,
 `PUBLORA_SIGNUP_URL`) remain importable from their submodules but are not
 re-exported here.
 """
+from ._env import load_env
 from .url_parser import parse_linkedin_url
 from .approval import render_approval_card
+
+load_env()
+
 from .backend_selector import (
     active_backend,
     image_backend,

--- a/.codex-marketplace/linkedin-skills/lib/_env.py
+++ b/.codex-marketplace/linkedin-skills/lib/_env.py
@@ -1,0 +1,36 @@
+"""Internal helper to load .env when python-dotenv is available."""
+from __future__ import annotations
+
+from pathlib import Path
+
+_ENV_LOADED = False
+
+
+def load_env(force: bool = False) -> None:
+    """Load environment variables from .env if python-dotenv is installed.
+
+    Safe no-op if python-dotenv is missing, preserving Tier 0 (manual)
+    zero-dependency operation. Searches upwards from the current working
+    directory and checks the repository root. Existing environment variables
+    are preserved.
+    """
+    global _ENV_LOADED
+    if _ENV_LOADED and not force:
+        return
+
+    try:
+        from dotenv import find_dotenv, load_dotenv
+
+        # 1. Search upwards from cwd (for plugin users working in project directories)
+        dotenv_path = find_dotenv(usecwd=True)
+        if dotenv_path:
+            load_dotenv(dotenv_path)
+
+        # 2. Check repo root relative to this file
+        repo_env = Path(__file__).resolve().parents[1] / ".env"
+        if repo_env.is_file():
+            load_dotenv(repo_env)
+    except ImportError:
+        pass
+
+    _ENV_LOADED = True

--- a/.codex-marketplace/linkedin-skills/lib/apify_client.py
+++ b/.codex-marketplace/linkedin-skills/lib/apify_client.py
@@ -39,6 +39,8 @@ from typing import Any, Optional
 
 import requests
 
+from ._env import load_env
+
 
 class ApifyError(RuntimeError):
     pass
@@ -88,7 +90,9 @@ class ApifyClient:
     )
 
     def __init__(self, token: Optional[str] = None, timeout: float = 180.0):
+        load_env()
         self.token = token or os.getenv("APIFY_TOKEN")
+
         if not self.token:
             raise ApifyError(
                 "APIFY_TOKEN not set. Export it or pass token= explicitly."

--- a/.codex-marketplace/linkedin-skills/lib/backend_selector.py
+++ b/.codex-marketplace/linkedin-skills/lib/backend_selector.py
@@ -31,8 +31,13 @@ import shlex
 import subprocess
 from typing import Any, Literal, Optional
 
+from ._env import load_env
+
+load_env()
+
 BackendName = Literal["publora", "manual", "diy"]
 PublishKind = Literal["comment", "reply", "post", "reshare"]
+
 
 PUBLORA_SIGNUP_URL = "https://app.publora.com/signup"
 

--- a/.codex-marketplace/linkedin-skills/lib/pixfaro_client.py
+++ b/.codex-marketplace/linkedin-skills/lib/pixfaro_client.py
@@ -36,6 +36,8 @@ from typing import Any, Optional
 
 import requests
 
+from ._env import load_env
+
 
 class PixfaroError(RuntimeError):
     def __init__(self, message: str, status_code: Optional[int] = None, retryable: bool = False):
@@ -77,6 +79,7 @@ class PixfaroClient:
     """One method that matters: `generate`. Returns the hosted image URL."""
 
     def __init__(self, api_key: Optional[str] = None, timeout: float = 90.0):
+        load_env()
         self.api_key = api_key or os.getenv("PIXFARO_TOKEN") or os.getenv("PIXFARO_API_KEY")
         if not self.api_key:
             raise PixfaroError(

--- a/.codex-marketplace/linkedin-skills/lib/publora_client.py
+++ b/.codex-marketplace/linkedin-skills/lib/publora_client.py
@@ -26,6 +26,8 @@ from typing import Any, Optional
 
 import requests
 
+from ._env import load_env
+
 
 class PubloraError(RuntimeError):
     pass
@@ -67,7 +69,9 @@ class PubloraClient:
     BASE_URL = "https://api.publora.com/api/v1"
 
     def __init__(self, api_key: Optional[str] = None, timeout: float = 30.0):
+        load_env()
         self.api_key = api_key or os.getenv("PUBLORA_API_KEY")
+
         if not self.api_key:
             raise PubloraError(
                 "PUBLORA_API_KEY not set. Export it or pass api_key= explicitly."

--- a/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/SKILL.md
+++ b/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/SKILL.md
@@ -62,7 +62,7 @@ linkedin-humanizer --mode audit <text>
 # Profile — build/update the user's Voice & Brand Profile so every writing
 # skill drafts in their real voice. Learns from 3-6 pasted posts (portable, no
 # token) or, if APIFY_TOKEN is set, from pulled activity. Writes
-# references/voice-profile.md. See sub-skills/voice-profile.md.
+# ../../references/voice-profile.md. See sub-skills/voice-profile.md.
 linkedin-humanizer --mode profile
 ```
 
@@ -141,7 +141,7 @@ See `references/examples.md` for worked examples.
 - `sub-skills/rules-explainer.md` — when to defend a flagged rule (em dash, rule of three, passive voice)
 - `sub-skills/emoji-detector.md` — scan / score / suggest workflow for emoji density
 - `sub-skills/detector-tester.md` — run text through 5 AI detectors in parallel and report disagreement
-- `sub-skills/voice-profile.md` — build/update the user's Voice & Brand Profile (`--mode profile`); the filled `references/voice-profile.md` is then read by every writing skill so drafts match the user's real voice
+- `sub-skills/voice-profile.md` — build/update the user's Voice & Brand Profile (`--mode profile`); the filled `../../references/voice-profile.md` is then read by every writing skill so drafts match the user's real voice
 - `scripts/test_detectors.py` — runs the parallel detector test (supports `--demo` for offline mode)
 - `scripts/requirements.txt` — Python deps for the detector script (`requests`, `python-dotenv`)
 - `scripts/detectors.env.example` — template for the 5 detector API keys

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -5,8 +5,12 @@ utilities (e.g., `build_parent_comment_urn`, `signup_nudge`,
 `PUBLORA_SIGNUP_URL`) remain importable from their submodules but are not
 re-exported here.
 """
+from ._env import load_env
 from .url_parser import parse_linkedin_url
 from .approval import render_approval_card
+
+load_env()
+
 from .backend_selector import (
     active_backend,
     image_backend,

--- a/lib/_env.py
+++ b/lib/_env.py
@@ -1,0 +1,36 @@
+"""Internal helper to load .env when python-dotenv is available."""
+from __future__ import annotations
+
+from pathlib import Path
+
+_ENV_LOADED = False
+
+
+def load_env(force: bool = False) -> None:
+    """Load environment variables from .env if python-dotenv is installed.
+
+    Safe no-op if python-dotenv is missing, preserving Tier 0 (manual)
+    zero-dependency operation. Searches upwards from the current working
+    directory and checks the repository root. Existing environment variables
+    are preserved.
+    """
+    global _ENV_LOADED
+    if _ENV_LOADED and not force:
+        return
+
+    try:
+        from dotenv import find_dotenv, load_dotenv
+
+        # 1. Search upwards from cwd (for plugin users working in project directories)
+        dotenv_path = find_dotenv(usecwd=True)
+        if dotenv_path:
+            load_dotenv(dotenv_path)
+
+        # 2. Check repo root relative to this file
+        repo_env = Path(__file__).resolve().parents[1] / ".env"
+        if repo_env.is_file():
+            load_dotenv(repo_env)
+    except ImportError:
+        pass
+
+    _ENV_LOADED = True

--- a/lib/apify_client.py
+++ b/lib/apify_client.py
@@ -39,6 +39,8 @@ from typing import Any, Optional
 
 import requests
 
+from ._env import load_env
+
 
 class ApifyError(RuntimeError):
     pass
@@ -88,7 +90,9 @@ class ApifyClient:
     )
 
     def __init__(self, token: Optional[str] = None, timeout: float = 180.0):
+        load_env()
         self.token = token or os.getenv("APIFY_TOKEN")
+
         if not self.token:
             raise ApifyError(
                 "APIFY_TOKEN not set. Export it or pass token= explicitly."

--- a/lib/backend_selector.py
+++ b/lib/backend_selector.py
@@ -31,8 +31,13 @@ import shlex
 import subprocess
 from typing import Any, Literal, Optional
 
+from ._env import load_env
+
+load_env()
+
 BackendName = Literal["publora", "manual", "diy"]
 PublishKind = Literal["comment", "reply", "post", "reshare"]
+
 
 PUBLORA_SIGNUP_URL = "https://app.publora.com/signup"
 

--- a/lib/pixfaro_client.py
+++ b/lib/pixfaro_client.py
@@ -36,6 +36,8 @@ from typing import Any, Optional
 
 import requests
 
+from ._env import load_env
+
 
 class PixfaroError(RuntimeError):
     def __init__(self, message: str, status_code: Optional[int] = None, retryable: bool = False):
@@ -77,6 +79,7 @@ class PixfaroClient:
     """One method that matters: `generate`. Returns the hosted image URL."""
 
     def __init__(self, api_key: Optional[str] = None, timeout: float = 90.0):
+        load_env()
         self.api_key = api_key or os.getenv("PIXFARO_TOKEN") or os.getenv("PIXFARO_API_KEY")
         if not self.api_key:
             raise PixfaroError(

--- a/lib/publora_client.py
+++ b/lib/publora_client.py
@@ -26,6 +26,8 @@ from typing import Any, Optional
 
 import requests
 
+from ._env import load_env
+
 
 class PubloraError(RuntimeError):
     pass
@@ -67,7 +69,9 @@ class PubloraClient:
     BASE_URL = "https://api.publora.com/api/v1"
 
     def __init__(self, api_key: Optional[str] = None, timeout: float = 30.0):
+        load_env()
         self.api_key = api_key or os.getenv("PUBLORA_API_KEY")
+
         if not self.api_key:
             raise PubloraError(
                 "PUBLORA_API_KEY not set. Export it or pass api_key= explicitly."

--- a/skills/linkedin-humanizer/SKILL.md
+++ b/skills/linkedin-humanizer/SKILL.md
@@ -62,7 +62,7 @@ linkedin-humanizer --mode audit <text>
 # Profile — build/update the user's Voice & Brand Profile so every writing
 # skill drafts in their real voice. Learns from 3-6 pasted posts (portable, no
 # token) or, if APIFY_TOKEN is set, from pulled activity. Writes
-# references/voice-profile.md. See sub-skills/voice-profile.md.
+# ../../references/voice-profile.md. See sub-skills/voice-profile.md.
 linkedin-humanizer --mode profile
 ```
 
@@ -141,7 +141,7 @@ See `references/examples.md` for worked examples.
 - `sub-skills/rules-explainer.md` — when to defend a flagged rule (em dash, rule of three, passive voice)
 - `sub-skills/emoji-detector.md` — scan / score / suggest workflow for emoji density
 - `sub-skills/detector-tester.md` — run text through 5 AI detectors in parallel and report disagreement
-- `sub-skills/voice-profile.md` — build/update the user's Voice & Brand Profile (`--mode profile`); the filled `references/voice-profile.md` is then read by every writing skill so drafts match the user's real voice
+- `sub-skills/voice-profile.md` — build/update the user's Voice & Brand Profile (`--mode profile`); the filled `../../references/voice-profile.md` is then read by every writing skill so drafts match the user's real voice
 - `scripts/test_detectors.py` — runs the parallel detector test (supports `--demo` for offline mode)
 - `scripts/requirements.txt` — Python deps for the detector script (`requests`, `python-dotenv`)
 - `scripts/detectors.env.example` — template for the 5 detector API keys


### PR DESCRIPTION
## Summary

This PR addresses the `.env` configuration gap noted in #21 as well as a broken reference path in `skills/linkedin-humanizer/SKILL.md`:

1. **Auto-load `.env`**:
   - Both `.env.example` and the interactive guidance in `lib/backend_selector.py:75, 116` prompt users to *"Add `PUBLORA_API_KEY` + `LINKEDIN_PLATFORM_ID` to `.env`"*.
   - Previously, nothing in `lib/` loaded `.env`, meaning users had to manually export variables into their shell session for `active_backend()`, `fetch_post()`, or the HTTP clients to recognize them.
   - Adds a lightweight helper `lib/_env.py` that utilizes `dotenv.find_dotenv(usecwd=True)` and checks the repo root to gracefully load `.env` variables if `python-dotenv` is present.
   - Preserves Tier 0 (manual) zero-dependency operation: if `python-dotenv` is missing, `load_env()` safely no-ops with zero runtime errors.

2. **Fix `voice-profile.md` reference path**:
   - `skills/linkedin-humanizer/SKILL.md` referenced `references/voice-profile.md` (in code comments and line 144) instead of `../../references/voice-profile.md`. Per `CLAUDE.md`, root references must use `../../references/`.

3. **Codex mirror sync**:
   - Refreshed `.codex-marketplace/linkedin-skills/` via `scripts/sync_codex_marketplace.py`.

## Validation

- Smoke test: `python -c "from lib import publish, fetch_post, illustrate, refine, ApifyClient, PubloraClient, PixfaroClient; print('OK')"` -> `OK`
- Verified `.env` file values are automatically discovered and loaded into `active_backend()`.
- Verified graceful fallback when `python-dotenv` is absent (Tier 0 remains 0-dep).
- All 12 `SKILL.md` files verified to parse under strict YAML (`yaml.safe_load`).
- Exactly 11 skills maintained; no em dashes in frontmatter descriptions.
