### PR TITLE
v1.0.34: .claude/skills symlink mirror so a plain clone auto-discover…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "linkedin-skills",
       "source": "./",
       "description": "Bundle of 11 LinkedIn marketing skills for Claude Code and Codex with verified 2026 hook formulas, comment + reply templates that earn author replies, a unified humanizer (rewrite + `--mode audit` pre-publish check, plus bundled emoji-detector, detector-spread tester, rule-explainer sub-tools), profile rewriter, content planner, employee advocacy playbook, thread monitor (warm-reply window author-reply tracking), and engager analytics (likers + commenters ICP segmentation).",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "author": {
         "name": "Serge Bulaev",
         "url": "https://github.com/sergebulaev"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "linkedin-skills",
       "source": "./",
       "description": "Bundle of 11 LinkedIn marketing skills for Claude Code and Codex with verified 2026 hook formulas, comment + reply templates that earn author replies, a unified humanizer (rewrite + `--mode audit` pre-publish check, plus bundled emoji-detector, detector-spread tester, rule-explainer sub-tools), profile rewriter, content planner, employee advocacy playbook, thread monitor (warm-reply window author-reply tracking), and engager analytics (likers + commenters ICP segmentation).",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "author": {
         "name": "Serge Bulaev",
         "url": "https://github.com/sergebulaev"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "linkedin-skills",
       "source": "./",
       "description": "Bundle of 11 LinkedIn marketing skills for Claude Code and Codex with verified 2026 hook formulas, comment + reply templates that earn author replies, a unified humanizer (rewrite + `--mode audit` pre-publish check, plus bundled emoji-detector, detector-spread tester, rule-explainer sub-tools), profile rewriter, content planner, employee advocacy playbook, thread monitor (warm-reply window author-reply tracking), and engager analytics (likers + commenters ICP segmentation).",
-      "version": "1.0.35",
+      "version": "1.0.36",
       "author": {
         "name": "Serge Bulaev",
         "url": "https://github.com/sergebulaev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.claude/skills/linkedin-comment-drafter
+++ b/.claude/skills/linkedin-comment-drafter
@@ -1,0 +1,1 @@
+../../skills/linkedin-comment-drafter

--- a/.claude/skills/linkedin-content-planner
+++ b/.claude/skills/linkedin-content-planner
@@ -1,0 +1,1 @@
+../../skills/linkedin-content-planner

--- a/.claude/skills/linkedin-employee-advocacy
+++ b/.claude/skills/linkedin-employee-advocacy
@@ -1,0 +1,1 @@
+../../skills/linkedin-employee-advocacy

--- a/.claude/skills/linkedin-engager-analytics
+++ b/.claude/skills/linkedin-engager-analytics
@@ -1,0 +1,1 @@
+../../skills/linkedin-engager-analytics

--- a/.claude/skills/linkedin-hook-extractor
+++ b/.claude/skills/linkedin-hook-extractor
@@ -1,0 +1,1 @@
+../../skills/linkedin-hook-extractor

--- a/.claude/skills/linkedin-humanizer
+++ b/.claude/skills/linkedin-humanizer
@@ -1,0 +1,1 @@
+../../skills/linkedin-humanizer

--- a/.claude/skills/linkedin-post-writer
+++ b/.claude/skills/linkedin-post-writer
@@ -1,0 +1,1 @@
+../../skills/linkedin-post-writer

--- a/.claude/skills/linkedin-profile-optimizer
+++ b/.claude/skills/linkedin-profile-optimizer
@@ -1,0 +1,1 @@
+../../skills/linkedin-profile-optimizer

--- a/.claude/skills/linkedin-reply-handler
+++ b/.claude/skills/linkedin-reply-handler
@@ -1,0 +1,1 @@
+../../skills/linkedin-reply-handler

--- a/.claude/skills/linkedin-repurposer
+++ b/.claude/skills/linkedin-repurposer
@@ -1,0 +1,1 @@
+../../skills/linkedin-repurposer

--- a/.claude/skills/linkedin-thread-monitor
+++ b/.claude/skills/linkedin-thread-monitor
@@ -1,0 +1,1 @@
+../../skills/linkedin-thread-monitor

--- a/.codex-marketplace/linkedin-skills/.codex-plugin/plugin.json
+++ b/.codex-marketplace/linkedin-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.codex-marketplace/linkedin-skills/.codex-plugin/plugin.json
+++ b/.codex-marketplace/linkedin-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.codex-marketplace/linkedin-skills/.codex-plugin/plugin.json
+++ b/.codex-marketplace/linkedin-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.codex-marketplace/linkedin-skills/README.md
+++ b/.codex-marketplace/linkedin-skills/README.md
@@ -86,6 +86,11 @@ git clone https://github.com/sergebulaev/linkedin-skills.git
 cd linkedin-skills
 ```
 
+The clone ships a `.claude/skills/` directory that symlinks all 11 skills, so
+Claude Code auto-discovers them the moment the repo is your working directory.
+No plugin install needed. Use this path wherever `/plugin` is unavailable, such
+as Claude Code on the web.
+
 ### Hermes Agent
 
 Hermes Agent (Nous Research) follows the agentskills.io open standard and loads `skills/*/SKILL.md` directly. Clone the bundle into your Hermes skills folder:
@@ -276,6 +281,7 @@ Every skill follows these rules automatically:
 ```
 linkedin-skills/
 ├── skills/          ← SKILL.md frontmatter; native to Claude Code and Codex, others read as markdown
+├── .claude/skills/  ← symlinks into skills/, so Claude Code auto-discovers the bundle from a plain clone
 ├── .codex-marketplace/ ← generated nested Codex package (run scripts/sync_codex_marketplace.py)
 ├── lib/             ← pure Python, works in any agent runtime
 ├── references/      ← pure markdown, works anywhere
@@ -284,7 +290,7 @@ linkedin-skills/
 
 | Runtime | Auto-discovers skills? | Setup |
 |---|---|---|
-| **Claude Code** (CLI, Desktop, Web, IDE) | Yes | Install via plugin or clone. Skills activate on matching prompts. |
+| **Claude Code** (CLI, Desktop, Web, IDE) | Yes | Install via plugin, or clone and open as the working directory (`.claude/skills/` makes the bundle discoverable without a plugin install). Skills activate on matching prompts. |
 | **Codex CLI** | Yes | Install via `codex plugin marketplace add sergebulaev/linkedin-skills` and `codex plugin add linkedin-skills@linkedin-skills`. |
 | **Anthropic Managed Agents** (`/v1/agents`) | Yes | Pass skill files in the agent context. |
 | **OpenClaw** | Manual | Mount the repo, add system prompt pointing to `skills/*/SKILL.md`. |

--- a/.codex-marketplace/linkedin-skills/README.md
+++ b/.codex-marketplace/linkedin-skills/README.md
@@ -230,7 +230,19 @@ Then open `.env` and replace the placeholders with your real values.
 pip install requests python-dotenv
 ```
 
-**Step 7.** Test it. Ask Claude Code or Codex:
+**Step 7.** Check the wiring:
+
+```bash
+python3 scripts/check_config.py
+```
+
+It reports each layer as configured, misconfigured, or simply not set up, and
+never prints a secret (credentials show as prefix plus length). Add `--offline`
+to skip the live API calls. The two silent failures it exists to catch: a `.env`
+that is never read because `python-dotenv` is missing, and a `PUBLORA_API_KEY`
+set without `LINKEDIN_PLATFORM_ID`, which quietly leaves you in draft-only mode.
+
+**Step 8.** Test it end to end. Ask Claude Code or Codex:
 
 > "Schedule a test LinkedIn post via Publora 24 hours from now: 'testing the API connection — will cancel in dashboard'."
 
@@ -257,8 +269,14 @@ Every skill follows these rules automatically:
 
 ## Troubleshooting
 
+Run `python3 scripts/check_config.py` first: it identifies most of the problems
+below by name, without printing your credentials.
+
 | Problem | Fix |
 |---|---|
+| I set up `.env` but nothing uses it | `python-dotenv` is not installed, so `.env` is silently ignored. `pip install python-dotenv`, or export the variables in your shell instead. |
+| Still draft-only despite a valid Publora key | Publishing needs `PUBLORA_API_KEY` **and** `LINKEDIN_PLATFORM_ID`. With only one set, the manual backend is selected with no warning. |
+| Skills keep asking me to paste post text | `APIFY_TOKEN` is unset, expired, or typo'd. Auth failures collapse into the same paste-fallback path as no token, so a wrong token looks exactly like none. |
 | Skills don't activate when I ask about LinkedIn | Make sure you installed via the Skills panel, `/plugin install`, or `codex plugin add`. Try starting a new conversation. |
 | "Publora API key not provided" | Your `.env` file is missing or in the wrong folder. It should be in the `linkedin-skills/` root. |
 | "401 Unauthorized" from Publora | Your API key expired. Go to Publora Settings > API > Create a new key. |

--- a/.codex-marketplace/linkedin-skills/scripts/check_config.py
+++ b/.codex-marketplace/linkedin-skills/scripts/check_config.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Diagnose the optional credential layers (Apify, Publora, Pixfaro).
+
+Every layer is optional: the bundle drafts fine with nothing configured, so an
+unconfigured layer is reported as a plain status, never a failure. What this
+catches is the case that is genuinely hard to spot by hand, a layer that looks
+configured but silently is not:
+
+* a ``.env`` that is never read, because ``python-dotenv`` is not installed
+  (``lib/_env.py`` swallows the ImportError by design);
+* ``PUBLORA_API_KEY`` without ``LINKEDIN_PLATFORM_ID``, which drops publishing
+  back to copy-paste with no warning (``lib/backend_selector.py``);
+* a typo'd or expired token, which collapses into the same "ask the user to
+  paste" path as no token at all.
+
+Secrets are never printed: a credential is shown as its non-secret prefix plus
+a length, which is enough to spot a truncated paste or a swapped key.
+
+Usage::
+
+    python3 scripts/check_config.py              # live checks against each API
+    python3 scripts/check_config.py --offline    # local wiring only, no network
+
+Exit status is 0 when nothing is misconfigured (all-unconfigured included) and
+1 when a configured layer is broken.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+import os
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+OK, WARN, BAD, OFF = "PASS", "WARN", "FAIL", "----"
+
+
+class Report:
+    """Collects one line per check and tracks whether anything is broken."""
+
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, str, str]] = []
+        self.failed = False
+
+    def add(self, status: str, label: str, detail: str = "") -> None:
+        self.rows.append((status, label, detail))
+        if status == BAD:
+            self.failed = True
+
+    def render(self, start: int = 0) -> None:
+        """Print rows added from index `start` on, aligned within that group."""
+        rows = self.rows[start:]
+        if not rows:
+            return
+        width = max(len(label) for _, label, _ in rows)
+        for status, label, detail in rows:
+            print(f"  [{status}] {label.ljust(width)}  {detail}".rstrip())
+
+
+def mask(value: str) -> str:
+    """Show a credential's shape without revealing it: prefix + length only."""
+    for prefix in ("apify_api_", "pf_live_", "sk_", "linkedin-"):
+        if value.startswith(prefix):
+            return f"{prefix}... ({len(value)} chars)"
+    return f"set ({len(value)} chars)"
+
+
+def section(title: str) -> None:
+    print(f"\n{title}\n{'-' * len(title)}")
+
+
+# --- local wiring ---------------------------------------------------------
+
+
+def check_environment(report: Report) -> None:
+    """The .env plumbing itself, checked before any credential is read."""
+    env_file = ROOT / ".env"
+    try:
+        import dotenv  # noqa: F401
+
+        has_dotenv = True
+    except ImportError:
+        has_dotenv = False
+
+    try:
+        import requests  # noqa: F401
+
+        has_requests = True
+    except ImportError:
+        has_requests = False
+
+    if env_file.is_file() and not has_dotenv:
+        report.add(
+            BAD,
+            ".env loading",
+            ".env exists but python-dotenv is missing, so it is IGNORED. Fix: pip install python-dotenv",
+        )
+    elif env_file.is_file():
+        report.add(OK, ".env loading", f"{env_file} found and loadable")
+    elif has_dotenv:
+        report.add(OFF, ".env loading", "no .env file; reading credentials from the shell environment")
+    else:
+        report.add(OFF, ".env loading", "no .env file and no python-dotenv; shell environment only")
+
+    report.add(
+        OK if has_requests else BAD,
+        "requests installed",
+        "" if has_requests else "required for every live API call. Fix: pip install requests",
+    )
+
+
+# --- credential layers ----------------------------------------------------
+
+
+def check_apify(report: Report, offline: bool) -> None:
+    token = os.getenv("APIFY_TOKEN")
+    if not token:
+        report.add(OFF, "APIFY_TOKEN", "not set; reading skills will ask you to paste text")
+        return
+
+    report.add(OK, "APIFY_TOKEN", mask(token))
+    if not token.startswith("apify_api_"):
+        report.add(WARN, "  token format", "expected an apify_api_ prefix; check for a truncated paste")
+    if offline:
+        return
+
+    try:
+        import requests
+
+        # The token goes in the Authorization header, never the query string:
+        # a query string leaks through logs, Referer headers and proxies.
+        r = requests.get(
+            "https://api.apify.com/v2/users/me",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
+        if r.status_code == 200:
+            username = (r.json().get("data") or {}).get("username", "?")
+            report.add(OK, "  live check", f"authenticated as {username}")
+        elif r.status_code in (401, 403):
+            report.add(BAD, "  live check", f"HTTP {r.status_code}: token rejected. Regenerate at console.apify.com/settings/integrations")
+        else:
+            report.add(BAD, "  live check", f"unexpected HTTP {r.status_code}")
+    except Exception as exc:  # network, DNS, TLS
+        report.add(WARN, "  live check", f"could not reach Apify ({type(exc).__name__}); token itself may still be fine")
+
+
+def check_publora(report: Report, offline: bool) -> None:
+    key = os.getenv("PUBLORA_API_KEY")
+    platform_id = os.getenv("LINKEDIN_PLATFORM_ID")
+
+    if not key and not platform_id:
+        report.add(OFF, "PUBLORA_API_KEY", "not set; publishing stays draft-only (copy-paste)")
+        return
+
+    # Publishing needs BOTH. One alone silently selects the manual backend.
+    if key and not platform_id:
+        report.add(OK, "PUBLORA_API_KEY", mask(key))
+        report.add(BAD, "LINKEDIN_PLATFORM_ID", "MISSING. Publishing silently stays draft-only until both are set")
+    elif platform_id and not key:
+        report.add(BAD, "PUBLORA_API_KEY", "MISSING. Publishing silently stays draft-only until both are set")
+        report.add(OK, "LINKEDIN_PLATFORM_ID", mask(platform_id))
+    else:
+        report.add(OK, "PUBLORA_API_KEY", mask(key))
+        report.add(OK, "LINKEDIN_PLATFORM_ID", mask(platform_id))
+
+    if key and not key.startswith("sk_"):
+        report.add(WARN, "  key format", "expected an sk_ prefix")
+    if platform_id and not platform_id.startswith("linkedin-"):
+        report.add(WARN, "  platform id format", "expected a linkedin- prefix; copy the whole string including it")
+
+    if offline or not key:
+        return
+
+    try:
+        import requests
+
+        r = requests.get(
+            "https://api.publora.com/api/v1/test-connection",
+            headers={"x-publora-key": key},
+            timeout=30,
+        )
+        if r.status_code == 200:
+            report.add(OK, "  live check", "key accepted")
+        elif r.status_code in (401, 403):
+            report.add(BAD, "  live check", f"HTTP {r.status_code}: key rejected. Settings > API > Create Key")
+        else:
+            report.add(BAD, "  live check", f"unexpected HTTP {r.status_code}")
+    except Exception as exc:
+        report.add(WARN, "  live check", f"could not reach Publora ({type(exc).__name__}); key itself may still be fine")
+
+
+def check_pixfaro(report: Report, offline: bool) -> None:
+    # PIXFARO_API_KEY is an accepted alias (see lib/pixfaro_client.py).
+    token = os.getenv("PIXFARO_TOKEN") or os.getenv("PIXFARO_API_KEY")
+    if not token:
+        report.add(OFF, "PIXFARO_TOKEN", "not set; image skills draft a prompt for you to run yourself")
+        return
+
+    name = "PIXFARO_TOKEN" if os.getenv("PIXFARO_TOKEN") else "PIXFARO_API_KEY (alias)"
+    report.add(OK, name, mask(token))
+    if not token.startswith("pf_live_"):
+        report.add(WARN, "  token format", "expected a pf_live_ prefix")
+    if offline:
+        return
+
+    try:
+        import requests
+
+        r = requests.get(
+            "https://api.pixfaro.com/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
+        if r.status_code == 200:
+            payload = r.json()
+            models = payload.get("data", payload) if isinstance(payload, dict) else payload
+            count = len(models) if isinstance(models, list) else "?"
+            report.add(OK, "  live check", f"{count} models available")
+        elif r.status_code in (401, 403):
+            report.add(BAD, "  live check", f"HTTP {r.status_code}: token rejected")
+        else:
+            report.add(BAD, "  live check", f"unexpected HTTP {r.status_code}")
+    except Exception as exc:
+        report.add(WARN, "  live check", f"could not reach Pixfaro ({type(exc).__name__}); token itself may still be fine")
+
+
+# --- effective behaviour --------------------------------------------------
+
+
+def check_backends(report: Report) -> None:
+    """What the skills will actually do, straight from the selector itself."""
+    try:
+        from lib.backend_selector import active_backend, image_backend
+    except Exception as exc:
+        report.add(BAD, "backend selector", f"could not import lib ({type(exc).__name__}: {exc})")
+        return
+
+    publish = active_backend()
+    images = image_backend()
+    explain = {
+        "publora": "posts publish to LinkedIn on your approval",
+        "diy": "hands drafts to your LINKEDIN_SKILLS_CUSTOM_POSTER command",
+        "manual": "drafts only, you copy-paste into LinkedIn",
+    }
+    report.add(OK, "publish backend", f"{publish} ({explain.get(publish, '')})")
+    report.add(
+        OK,
+        "reading backend",
+        "apify (auto-fetch)" if os.getenv("APIFY_TOKEN") else "manual (you paste post text)",
+    )
+    report.add(
+        OK,
+        "image backend",
+        "pixfaro (auto-generate)" if images == "pixfaro" else "manual (prompt drafted for you)",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="skip live API calls; check local wiring and variable shape only",
+    )
+    args = parser.parse_args()
+
+    try:
+        from lib._env import load_env
+
+        load_env()
+    except Exception:
+        pass  # .env loading is best-effort; check_environment reports on it
+
+    report = Report()
+
+    def run(title: str, *checks) -> None:
+        """Run a section's checks, then render only the rows they added."""
+        start = len(report.rows)
+        for check in checks:
+            check()
+        section(title)
+        report.render(start)
+
+    run("Environment", lambda: check_environment(report))
+    run(
+        "Credentials" + (" (offline: shape only)" if args.offline else ""),
+        lambda: check_apify(report, args.offline),
+        lambda: check_publora(report, args.offline),
+        lambda: check_pixfaro(report, args.offline),
+    )
+    run("Effective behaviour", lambda: check_backends(report))
+
+    print()
+    if report.failed:
+        print("Something is configured but broken. See the FAIL lines above.")
+        return 1
+    print("No misconfiguration found. Layers marked ---- are simply not set up.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex-marketplace/linkedin-skills/scripts/check_config.py
+++ b/.codex-marketplace/linkedin-skills/scripts/check_config.py
@@ -176,16 +176,40 @@ def check_publora(report: Report, offline: bool) -> None:
     if offline or not key:
         return
 
+    # GET /platform-connections is the documented way to verify a key: it
+    # lists the workspace's connected channels, so the same call also proves
+    # LINKEDIN_PLATFORM_ID names a real channel. (Publora's "test-connection"
+    # is a per-platform bot check, not an API-key check.) Schema, from
+    # publora/publora-api-docs schema/openapi.yaml:
+    #   200 -> {"success": bool, "connections": [{"platformId": "linkedin-...",
+    #           "username": "@handle", "displayName": "...", ...}]}
+    #   401 -> {"error": "Invalid API key", "code": "..."}
     try:
         import requests
 
         r = requests.get(
-            "https://api.publora.com/api/v1/test-connection",
+            "https://api.publora.com/api/v1/platform-connections",
             headers={"x-publora-key": key},
             timeout=30,
         )
         if r.status_code == 200:
-            report.add(OK, "  live check", "key accepted")
+            payload = r.json() if r.content else {}
+            connections = payload.get("connections") or [] if isinstance(payload, dict) else []
+            ids = [c.get("platformId", "") for c in connections if isinstance(c, dict)]
+            linkedin = [c for c in connections if isinstance(c, dict) and str(c.get("platformId", "")).startswith("linkedin-")]
+            report.add(OK, "  live check", f"key accepted; {len(connections)} connected channel(s), {len(linkedin)} LinkedIn")
+
+            if not platform_id:
+                pass  # already reported as BAD above
+            elif platform_id in ids:
+                match = next(c for c in connections if c.get("platformId") == platform_id)
+                who = match.get("displayName") or match.get("username") or "(unnamed)"
+                report.add(OK, "  platform id match", f"names a connected channel: {who}")
+            elif not linkedin:
+                report.add(BAD, "  platform id match", "no LinkedIn channel is connected in this Publora workspace. Channels > Add Channel > LinkedIn")
+            else:
+                names = ", ".join(str(c.get("displayName") or c.get("username") or "?") for c in linkedin)
+                report.add(BAD, "  platform id match", f"LINKEDIN_PLATFORM_ID does not match any connected channel. Connected LinkedIn channel(s): {names}. Copy the id from Channels > your account")
         elif r.status_code in (401, 403):
             report.add(BAD, "  live check", f"HTTP {r.status_code}: key rejected. Settings > API > Create Key")
         else:

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linkedin-skills",
   "description": "11 Claude Code and Codex skills for LinkedIn marketing: post writing, comment drafting, reply handler, hook extractor, humanizer (rewrite + audit + emoji + detector + rules sub-tools), profile optimizer, content planner, content repurposer, employee advocacy, thread monitor (author replies), engager analytics (likers + commenters ICP segmentation).",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "author": {
     "name": "Serge Bulaev",
     "url": "https://github.com/sergebulaev"

--- a/.env
+++ b/.env
@@ -6,11 +6,11 @@
 
 # Publora API key — sign up free at https://app.publora.com/signup
 # 15 LinkedIn + Bluesky posts/month on free tier
-PUBLORA_API_KEY=sk_your_key_here
+PUBLORA_API_KEY=sk_mts15gfe_ab0d47b3.637384308858dc5b071a436a4c517ac7317073f1a255524bc1f1
 
 # LinkedIn platform connection ID (format: linkedin-ABC123)
 # Find this in the Publora dashboard: Channels → your LinkedIn account
-LINKEDIN_PLATFORM_ID=linkedin-your_id_here
+LINKEDIN_PLATFORM_ID=linkedin-SrikanthParvathala
 
 # ─────────────────────────────────────────────────────────────────
 # Apify token (optional) - lets the skills fetch LinkedIn post bodies,
@@ -24,7 +24,7 @@ LINKEDIN_PLATFORM_ID=linkedin-your_id_here
 # Without a token, the skills fall back to asking you to paste post
 # text or comment URLs by hand.
 # ─────────────────────────────────────────────────────────────────
-APIFY_TOKEN=apify_api_your_token_here
+APIFY_TOKEN=apify_api_RYnabJ5Fw05siWtHpjsYIZ9a4JavpK2aralO
 
 # ─────────────────────────────────────────────────────────────────
 # Pixfaro token (optional) - lets the skills generate illustrations for

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ PUBLORA_API_KEY=sk_mts15gfe_ab0d47b3.637384308858dc5b071a436a4c517ac7317073f1a25
 
 # LinkedIn platform connection ID (format: linkedin-ABC123)
 # Find this in the Publora dashboard: Channels → your LinkedIn account
-LINKEDIN_PLATFORM_ID=linkedin-SrikanthParvathala
+LINKEDIN_PLATFORM_ID=linkedin-rmFFnmyeRo
 
 # ─────────────────────────────────────────────────────────────────
 # Apify token (optional) - lets the skills fetch LinkedIn post bodies,

--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,11 @@
 
 # Publora API key — sign up free at https://app.publora.com/signup
 # 15 LinkedIn + Bluesky posts/month on free tier
-PUBLORA_API_KEY=sk_mts15gfe_ab0d47b3.637384308858dc5b071a436a4c517ac7317073f1a255524bc1f1
+PUBLORA_API_KEY=sk_your_key_here
 
 # LinkedIn platform connection ID (format: linkedin-ABC123)
 # Find this in the Publora dashboard: Channels → your LinkedIn account
-LINKEDIN_PLATFORM_ID=linkedin-rmFFnmyeRo
+LINKEDIN_PLATFORM_ID=linkedin-your_id_here
 
 # ─────────────────────────────────────────────────────────────────
 # Apify token (optional) - lets the skills fetch LinkedIn post bodies,
@@ -24,7 +24,7 @@ LINKEDIN_PLATFORM_ID=linkedin-rmFFnmyeRo
 # Without a token, the skills fall back to asking you to paste post
 # text or comment URLs by hand.
 # ─────────────────────────────────────────────────────────────────
-APIFY_TOKEN=apify_api_RYnabJ5Fw05siWtHpjsYIZ9a4JavpK2aralO
+APIFY_TOKEN=apify_api_your_token_here
 
 # ─────────────────────────────────────────────────────────────────
 # Pixfaro token (optional) - lets the skills generate illustrations for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,14 @@ otherwise.
   prose are allowed for table separators and list dividers only.
 - **Skill names are public surface.** Renaming a skill is a major
   version bump and requires updating: plugin manifests, marketplace entries,
-  root `SKILL.md` bundle list, README skill table, every `linkedin-<name>`
+  root `SKILL.md` bundle list, README skill table, the
+  `.claude/skills/<name>` symlink, every `linkedin-<name>`
   cross-reference in sibling SKILL.md files.
+- **`.claude/skills/` is a symlink mirror, never a copy.** One relative
+  symlink per skill (`.claude/skills/<name>` -> `../../skills/<name>`) so
+  Claude Code auto-discovers the bundle from a plain clone. It is
+  Claude-specific and is not copied into the Codex package; `skills/` stays
+  the single source of truth.
 
 ## Voice rules + reference layout
 
@@ -132,6 +138,8 @@ python3 -c "from lib import publish, fetch_post, ApifyClient, PubloraClient; pri
 python3 scripts/sync_codex_marketplace.py
 wc -l SKILL.md skills/*/SKILL.md
 ls skills/ | wc -l        # must equal 11
+ls .claude/skills | wc -l # must equal 11
+for l in .claude/skills/*; do [ -e "$l" ] || echo "BROKEN SYMLINK: $l"; done
 grep -nE '^description:' skills/*/SKILL.md SKILL.md | grep -P '\\x{2014}|\\x{2013}'   # must be empty
 python3 -m json.tool .codex-plugin/plugin.json >/dev/null
 python3 -m json.tool .agents/plugins/marketplace.json >/dev/null

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ wc -l SKILL.md skills/*/SKILL.md
 ls skills/ | wc -l        # must equal 11
 ls .claude/skills | wc -l # must equal 11
 for l in .claude/skills/*; do [ -e "$l" ] || echo "BROKEN SYMLINK: $l"; done
+python3 scripts/check_config.py --offline   # credential wiring; 0 when nothing is misconfigured
 grep -nE '^description:' skills/*/SKILL.md SKILL.md | grep -P '\\x{2014}|\\x{2013}'   # must be empty
 python3 -m json.tool .codex-plugin/plugin.json >/dev/null
 python3 -m json.tool .agents/plugins/marketplace.json >/dev/null

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,13 @@ otherwise.
   version bump and requires updating: `.codex-plugin/plugin.json`,
   `.agents/plugins/marketplace.json`, `.claude-plugin/plugin.json`,
   `.claude-plugin/marketplace.json`, root `SKILL.md` bundle list,
-  README skill table, every
+  README skill table, the `.claude/skills/<name>` symlink, every
   `linkedin-<name>` cross-reference in sibling SKILL.md files.
+- **`.claude/skills/` is a symlink mirror, never a copy.** One relative
+  symlink per skill (`.claude/skills/<name>` -> `../../skills/<name>`) so
+  Claude Code auto-discovers the bundle from a plain clone, with no plugin
+  install. `skills/` stays the single source of truth. Adding or renaming a
+  skill means adding or renaming its symlink in the same commit.
 
 ## Voice rules + reference layout
 
@@ -144,6 +149,8 @@ python3 -c "from lib import publish, fetch_post, illustrate, refine, ApifyClient
 python3 scripts/sync_codex_marketplace.py
 wc -l SKILL.md skills/*/SKILL.md
 ls skills/ | wc -l        # must equal 11
+ls .claude/skills | wc -l # must equal 11
+for l in .claude/skills/*; do [ -e "$l" ] || echo "BROKEN SYMLINK: $l"; done
 grep -nE '^description:' skills/*/SKILL.md SKILL.md | grep -E '—|–'   # must be empty
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ wc -l SKILL.md skills/*/SKILL.md
 ls skills/ | wc -l        # must equal 11
 ls .claude/skills | wc -l # must equal 11
 for l in .claude/skills/*; do [ -e "$l" ] || echo "BROKEN SYMLINK: $l"; done
+python3 scripts/check_config.py --offline   # credential wiring; 0 when nothing is misconfigured
 grep -nE '^description:' skills/*/SKILL.md SKILL.md | grep -E '—|–'   # must be empty
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ git clone https://github.com/sergebulaev/linkedin-skills.git
 cd linkedin-skills
 ```
 
+The clone ships a `.claude/skills/` directory that symlinks all 11 skills, so
+Claude Code auto-discovers them the moment the repo is your working directory.
+No plugin install needed. Use this path wherever `/plugin` is unavailable, such
+as Claude Code on the web.
+
 ### Hermes Agent
 
 Hermes Agent (Nous Research) follows the agentskills.io open standard and loads `skills/*/SKILL.md` directly. Clone the bundle into your Hermes skills folder:
@@ -276,6 +281,7 @@ Every skill follows these rules automatically:
 ```
 linkedin-skills/
 ├── skills/          ← SKILL.md frontmatter; native to Claude Code and Codex, others read as markdown
+├── .claude/skills/  ← symlinks into skills/, so Claude Code auto-discovers the bundle from a plain clone
 ├── .codex-marketplace/ ← generated nested Codex package (run scripts/sync_codex_marketplace.py)
 ├── lib/             ← pure Python, works in any agent runtime
 ├── references/      ← pure markdown, works anywhere
@@ -284,7 +290,7 @@ linkedin-skills/
 
 | Runtime | Auto-discovers skills? | Setup |
 |---|---|---|
-| **Claude Code** (CLI, Desktop, Web, IDE) | Yes | Install via plugin or clone. Skills activate on matching prompts. |
+| **Claude Code** (CLI, Desktop, Web, IDE) | Yes | Install via plugin, or clone and open as the working directory (`.claude/skills/` makes the bundle discoverable without a plugin install). Skills activate on matching prompts. |
 | **Codex CLI** | Yes | Install via `codex plugin marketplace add sergebulaev/linkedin-skills` and `codex plugin add linkedin-skills@linkedin-skills`. |
 | **Anthropic Managed Agents** (`/v1/agents`) | Yes | Pass skill files in the agent context. |
 | **OpenClaw** | Manual | Mount the repo, add system prompt pointing to `skills/*/SKILL.md`. |

--- a/README.md
+++ b/README.md
@@ -230,7 +230,19 @@ Then open `.env` and replace the placeholders with your real values.
 pip install requests python-dotenv
 ```
 
-**Step 7.** Test it. Ask Claude Code or Codex:
+**Step 7.** Check the wiring:
+
+```bash
+python3 scripts/check_config.py
+```
+
+It reports each layer as configured, misconfigured, or simply not set up, and
+never prints a secret (credentials show as prefix plus length). Add `--offline`
+to skip the live API calls. The two silent failures it exists to catch: a `.env`
+that is never read because `python-dotenv` is missing, and a `PUBLORA_API_KEY`
+set without `LINKEDIN_PLATFORM_ID`, which quietly leaves you in draft-only mode.
+
+**Step 8.** Test it end to end. Ask Claude Code or Codex:
 
 > "Schedule a test LinkedIn post via Publora 24 hours from now: 'testing the API connection — will cancel in dashboard'."
 
@@ -257,8 +269,14 @@ Every skill follows these rules automatically:
 
 ## Troubleshooting
 
+Run `python3 scripts/check_config.py` first: it identifies most of the problems
+below by name, without printing your credentials.
+
 | Problem | Fix |
 |---|---|
+| I set up `.env` but nothing uses it | `python-dotenv` is not installed, so `.env` is silently ignored. `pip install python-dotenv`, or export the variables in your shell instead. |
+| Still draft-only despite a valid Publora key | Publishing needs `PUBLORA_API_KEY` **and** `LINKEDIN_PLATFORM_ID`. With only one set, the manual backend is selected with no warning. |
+| Skills keep asking me to paste post text | `APIFY_TOKEN` is unset, expired, or typo'd. Auth failures collapse into the same paste-fallback path as no token, so a wrong token looks exactly like none. |
 | Skills don't activate when I ask about LinkedIn | Make sure you installed via the Skills panel, `/plugin install`, or `codex plugin add`. Try starting a new conversation. |
 | "Publora API key not provided" | Your `.env` file is missing or in the wrong folder. It should be in the `linkedin-skills/` root. |
 | "401 Unauthorized" from Publora | Your API key expired. Go to Publora Settings > API > Create a new key. |

--- a/scripts/check_config.py
+++ b/scripts/check_config.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Diagnose the optional credential layers (Apify, Publora, Pixfaro).
+
+Every layer is optional: the bundle drafts fine with nothing configured, so an
+unconfigured layer is reported as a plain status, never a failure. What this
+catches is the case that is genuinely hard to spot by hand, a layer that looks
+configured but silently is not:
+
+* a ``.env`` that is never read, because ``python-dotenv`` is not installed
+  (``lib/_env.py`` swallows the ImportError by design);
+* ``PUBLORA_API_KEY`` without ``LINKEDIN_PLATFORM_ID``, which drops publishing
+  back to copy-paste with no warning (``lib/backend_selector.py``);
+* a typo'd or expired token, which collapses into the same "ask the user to
+  paste" path as no token at all.
+
+Secrets are never printed: a credential is shown as its non-secret prefix plus
+a length, which is enough to spot a truncated paste or a swapped key.
+
+Usage::
+
+    python3 scripts/check_config.py              # live checks against each API
+    python3 scripts/check_config.py --offline    # local wiring only, no network
+
+Exit status is 0 when nothing is misconfigured (all-unconfigured included) and
+1 when a configured layer is broken.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+import os
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+OK, WARN, BAD, OFF = "PASS", "WARN", "FAIL", "----"
+
+
+class Report:
+    """Collects one line per check and tracks whether anything is broken."""
+
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, str, str]] = []
+        self.failed = False
+
+    def add(self, status: str, label: str, detail: str = "") -> None:
+        self.rows.append((status, label, detail))
+        if status == BAD:
+            self.failed = True
+
+    def render(self, start: int = 0) -> None:
+        """Print rows added from index `start` on, aligned within that group."""
+        rows = self.rows[start:]
+        if not rows:
+            return
+        width = max(len(label) for _, label, _ in rows)
+        for status, label, detail in rows:
+            print(f"  [{status}] {label.ljust(width)}  {detail}".rstrip())
+
+
+def mask(value: str) -> str:
+    """Show a credential's shape without revealing it: prefix + length only."""
+    for prefix in ("apify_api_", "pf_live_", "sk_", "linkedin-"):
+        if value.startswith(prefix):
+            return f"{prefix}... ({len(value)} chars)"
+    return f"set ({len(value)} chars)"
+
+
+def section(title: str) -> None:
+    print(f"\n{title}\n{'-' * len(title)}")
+
+
+# --- local wiring ---------------------------------------------------------
+
+
+def check_environment(report: Report) -> None:
+    """The .env plumbing itself, checked before any credential is read."""
+    env_file = ROOT / ".env"
+    try:
+        import dotenv  # noqa: F401
+
+        has_dotenv = True
+    except ImportError:
+        has_dotenv = False
+
+    try:
+        import requests  # noqa: F401
+
+        has_requests = True
+    except ImportError:
+        has_requests = False
+
+    if env_file.is_file() and not has_dotenv:
+        report.add(
+            BAD,
+            ".env loading",
+            ".env exists but python-dotenv is missing, so it is IGNORED. Fix: pip install python-dotenv",
+        )
+    elif env_file.is_file():
+        report.add(OK, ".env loading", f"{env_file} found and loadable")
+    elif has_dotenv:
+        report.add(OFF, ".env loading", "no .env file; reading credentials from the shell environment")
+    else:
+        report.add(OFF, ".env loading", "no .env file and no python-dotenv; shell environment only")
+
+    report.add(
+        OK if has_requests else BAD,
+        "requests installed",
+        "" if has_requests else "required for every live API call. Fix: pip install requests",
+    )
+
+
+# --- credential layers ----------------------------------------------------
+
+
+def check_apify(report: Report, offline: bool) -> None:
+    token = os.getenv("APIFY_TOKEN")
+    if not token:
+        report.add(OFF, "APIFY_TOKEN", "not set; reading skills will ask you to paste text")
+        return
+
+    report.add(OK, "APIFY_TOKEN", mask(token))
+    if not token.startswith("apify_api_"):
+        report.add(WARN, "  token format", "expected an apify_api_ prefix; check for a truncated paste")
+    if offline:
+        return
+
+    try:
+        import requests
+
+        # The token goes in the Authorization header, never the query string:
+        # a query string leaks through logs, Referer headers and proxies.
+        r = requests.get(
+            "https://api.apify.com/v2/users/me",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
+        if r.status_code == 200:
+            username = (r.json().get("data") or {}).get("username", "?")
+            report.add(OK, "  live check", f"authenticated as {username}")
+        elif r.status_code in (401, 403):
+            report.add(BAD, "  live check", f"HTTP {r.status_code}: token rejected. Regenerate at console.apify.com/settings/integrations")
+        else:
+            report.add(BAD, "  live check", f"unexpected HTTP {r.status_code}")
+    except Exception as exc:  # network, DNS, TLS
+        report.add(WARN, "  live check", f"could not reach Apify ({type(exc).__name__}); token itself may still be fine")
+
+
+def check_publora(report: Report, offline: bool) -> None:
+    key = os.getenv("PUBLORA_API_KEY")
+    platform_id = os.getenv("LINKEDIN_PLATFORM_ID")
+
+    if not key and not platform_id:
+        report.add(OFF, "PUBLORA_API_KEY", "not set; publishing stays draft-only (copy-paste)")
+        return
+
+    # Publishing needs BOTH. One alone silently selects the manual backend.
+    if key and not platform_id:
+        report.add(OK, "PUBLORA_API_KEY", mask(key))
+        report.add(BAD, "LINKEDIN_PLATFORM_ID", "MISSING. Publishing silently stays draft-only until both are set")
+    elif platform_id and not key:
+        report.add(BAD, "PUBLORA_API_KEY", "MISSING. Publishing silently stays draft-only until both are set")
+        report.add(OK, "LINKEDIN_PLATFORM_ID", mask(platform_id))
+    else:
+        report.add(OK, "PUBLORA_API_KEY", mask(key))
+        report.add(OK, "LINKEDIN_PLATFORM_ID", mask(platform_id))
+
+    if key and not key.startswith("sk_"):
+        report.add(WARN, "  key format", "expected an sk_ prefix")
+    if platform_id and not platform_id.startswith("linkedin-"):
+        report.add(WARN, "  platform id format", "expected a linkedin- prefix; copy the whole string including it")
+
+    if offline or not key:
+        return
+
+    try:
+        import requests
+
+        r = requests.get(
+            "https://api.publora.com/api/v1/test-connection",
+            headers={"x-publora-key": key},
+            timeout=30,
+        )
+        if r.status_code == 200:
+            report.add(OK, "  live check", "key accepted")
+        elif r.status_code in (401, 403):
+            report.add(BAD, "  live check", f"HTTP {r.status_code}: key rejected. Settings > API > Create Key")
+        else:
+            report.add(BAD, "  live check", f"unexpected HTTP {r.status_code}")
+    except Exception as exc:
+        report.add(WARN, "  live check", f"could not reach Publora ({type(exc).__name__}); key itself may still be fine")
+
+
+def check_pixfaro(report: Report, offline: bool) -> None:
+    # PIXFARO_API_KEY is an accepted alias (see lib/pixfaro_client.py).
+    token = os.getenv("PIXFARO_TOKEN") or os.getenv("PIXFARO_API_KEY")
+    if not token:
+        report.add(OFF, "PIXFARO_TOKEN", "not set; image skills draft a prompt for you to run yourself")
+        return
+
+    name = "PIXFARO_TOKEN" if os.getenv("PIXFARO_TOKEN") else "PIXFARO_API_KEY (alias)"
+    report.add(OK, name, mask(token))
+    if not token.startswith("pf_live_"):
+        report.add(WARN, "  token format", "expected a pf_live_ prefix")
+    if offline:
+        return
+
+    try:
+        import requests
+
+        r = requests.get(
+            "https://api.pixfaro.com/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
+        if r.status_code == 200:
+            payload = r.json()
+            models = payload.get("data", payload) if isinstance(payload, dict) else payload
+            count = len(models) if isinstance(models, list) else "?"
+            report.add(OK, "  live check", f"{count} models available")
+        elif r.status_code in (401, 403):
+            report.add(BAD, "  live check", f"HTTP {r.status_code}: token rejected")
+        else:
+            report.add(BAD, "  live check", f"unexpected HTTP {r.status_code}")
+    except Exception as exc:
+        report.add(WARN, "  live check", f"could not reach Pixfaro ({type(exc).__name__}); token itself may still be fine")
+
+
+# --- effective behaviour --------------------------------------------------
+
+
+def check_backends(report: Report) -> None:
+    """What the skills will actually do, straight from the selector itself."""
+    try:
+        from lib.backend_selector import active_backend, image_backend
+    except Exception as exc:
+        report.add(BAD, "backend selector", f"could not import lib ({type(exc).__name__}: {exc})")
+        return
+
+    publish = active_backend()
+    images = image_backend()
+    explain = {
+        "publora": "posts publish to LinkedIn on your approval",
+        "diy": "hands drafts to your LINKEDIN_SKILLS_CUSTOM_POSTER command",
+        "manual": "drafts only, you copy-paste into LinkedIn",
+    }
+    report.add(OK, "publish backend", f"{publish} ({explain.get(publish, '')})")
+    report.add(
+        OK,
+        "reading backend",
+        "apify (auto-fetch)" if os.getenv("APIFY_TOKEN") else "manual (you paste post text)",
+    )
+    report.add(
+        OK,
+        "image backend",
+        "pixfaro (auto-generate)" if images == "pixfaro" else "manual (prompt drafted for you)",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="skip live API calls; check local wiring and variable shape only",
+    )
+    args = parser.parse_args()
+
+    try:
+        from lib._env import load_env
+
+        load_env()
+    except Exception:
+        pass  # .env loading is best-effort; check_environment reports on it
+
+    report = Report()
+
+    def run(title: str, *checks) -> None:
+        """Run a section's checks, then render only the rows they added."""
+        start = len(report.rows)
+        for check in checks:
+            check()
+        section(title)
+        report.render(start)
+
+    run("Environment", lambda: check_environment(report))
+    run(
+        "Credentials" + (" (offline: shape only)" if args.offline else ""),
+        lambda: check_apify(report, args.offline),
+        lambda: check_publora(report, args.offline),
+        lambda: check_pixfaro(report, args.offline),
+    )
+    run("Effective behaviour", lambda: check_backends(report))
+
+    print()
+    if report.failed:
+        print("Something is configured but broken. See the FAIL lines above.")
+        return 1
+    print("No misconfiguration found. Layers marked ---- are simply not set up.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_config.py
+++ b/scripts/check_config.py
@@ -176,16 +176,40 @@ def check_publora(report: Report, offline: bool) -> None:
     if offline or not key:
         return
 
+    # GET /platform-connections is the documented way to verify a key: it
+    # lists the workspace's connected channels, so the same call also proves
+    # LINKEDIN_PLATFORM_ID names a real channel. (Publora's "test-connection"
+    # is a per-platform bot check, not an API-key check.) Schema, from
+    # publora/publora-api-docs schema/openapi.yaml:
+    #   200 -> {"success": bool, "connections": [{"platformId": "linkedin-...",
+    #           "username": "@handle", "displayName": "...", ...}]}
+    #   401 -> {"error": "Invalid API key", "code": "..."}
     try:
         import requests
 
         r = requests.get(
-            "https://api.publora.com/api/v1/test-connection",
+            "https://api.publora.com/api/v1/platform-connections",
             headers={"x-publora-key": key},
             timeout=30,
         )
         if r.status_code == 200:
-            report.add(OK, "  live check", "key accepted")
+            payload = r.json() if r.content else {}
+            connections = payload.get("connections") or [] if isinstance(payload, dict) else []
+            ids = [c.get("platformId", "") for c in connections if isinstance(c, dict)]
+            linkedin = [c for c in connections if isinstance(c, dict) and str(c.get("platformId", "")).startswith("linkedin-")]
+            report.add(OK, "  live check", f"key accepted; {len(connections)} connected channel(s), {len(linkedin)} LinkedIn")
+
+            if not platform_id:
+                pass  # already reported as BAD above
+            elif platform_id in ids:
+                match = next(c for c in connections if c.get("platformId") == platform_id)
+                who = match.get("displayName") or match.get("username") or "(unnamed)"
+                report.add(OK, "  platform id match", f"names a connected channel: {who}")
+            elif not linkedin:
+                report.add(BAD, "  platform id match", "no LinkedIn channel is connected in this Publora workspace. Channels > Add Channel > LinkedIn")
+            else:
+                names = ", ".join(str(c.get("displayName") or c.get("username") or "?") for c in linkedin)
+                report.add(BAD, "  platform id match", f"LINKEDIN_PLATFORM_ID does not match any connected channel. Connected LinkedIn channel(s): {names}. Copy the id from Channels > your account")
         elif r.status_code in (401, 403):
             report.add(BAD, "  live check", f"HTTP {r.status_code}: key rejected. Settings > API > Create Key")
         else:


### PR DESCRIPTION
…s all 11 skills

Claude Code discovers project skills at .claude/skills/, but the bundle keeps its skills at skills/ (the agentskills.io + plugin layout). That meant the README's "clone the repo and open it as your working directory" path did not actually activate anything, and there was no install route at all where /plugin is unavailable (Claude Code on the web).

Add .claude/skills/<name> -> ../../skills/<name>, one relative symlink per skill. skills/ stays the single source of truth: no copies, no sync step. Relative refs still resolve, since symlinks resolve physically -- a skill's ../../references/ lands on the repo root, not on .claude/.

The mirror is Claude-specific and is not copied into the Codex package.

- README: document the no-plugin-install path and the runtime compat row
- CLAUDE.md / AGENTS.md: symlink-mirror invariant, rename checklist entry, and a broken-symlink check in the pre-push validation block
- bump 1.0.33 -> 1.0.34 across all four manifests, resync Codex package


Claude-Session: https://claude.ai/code/session_0169yBVU85FpXR2YjQW8SAy5