### PR TITLE
Fix claude.ai (web) install instructions use Plugins tab not Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,17 @@ cd linkedin-skills
 codex plugin marketplace add .
 codex plugin add linkedin-skills@linkedin-skills
 ```
-
 ### claude.ai (web)
 
-1. Open https://claude.ai/code
-2. Go to **Skills** in the sidebar
-3. Click **Add from GitHub**
-4. Paste: `sergebulaev/linkedin-skills`
-5. Done. The skills activate automatically when you ask about LinkedIn.
+1. Open [claude.ai](https://claude.ai) and click **Customize** in the sidebar
+2. Click **Plugins** (right next to Skills, Connectors)
+3. Click the **Add** button (top-right spot)
+4. Look for **Add marketplace** → **Add from a repository**
+5. Paste `sergebulaev/linkedin-skills` there and sync
+6. Find the plugin under **Discover**, then click **Add**
+7. Done. The skills activate automatically when you ask about LinkedIn.
+
+> Note: Skills/Plugins require a paid Claude plan (Pro, Max, Team, or Enterprise) with code execution enabled.
 
 ### Claude Desktop (Mac / Windows)
 


### PR DESCRIPTION
Summary:
Updated the claude.ai (web) install instructions the previous steps ("Go to Skills in the sidebar, click Add from GitHub") no longer match the current UI.

Why:
This repo is packaged as a plugin marketplace (it has a `.claude-plugin` folder), so on claude.ai it needs to be added through the Plugins tab not Skills. The old instructions pointed users to a button that doesn't exist for this kind of repo which caused confusion (ran into this myself and the fix below is confirmed working).

Changes:
- Replaced the outdated steps with the current flow: Customize → Plugins tab → Add → Add marketplace → Add from a repository → paste repo path → sync → find under Discover → Add
- Added a note that Skills/Plugins require a paid Claude plan (Pro/Max/Team/Enterprise) with code execution enabled since that's another common blocker