### PR TITLE
fix(humanizer): make linkedin_2026 regex compile on Python 3.11+

### DIFF
--- a/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/references/audit-ai-tells.md
+++ b/.codex-marketplace/linkedin-skills/skills/linkedin-humanizer/references/audit-ai-tells.md
@@ -132,7 +132,8 @@ DENSITY_PATTERNS = {
     "adverb_filler": r"(?i)\b(fundamentally|essentially|ultimately|arguably|certainly|definitely|undoubtedly)\b",
     "ing_opener": r"(?m)^[\s>*\-]*[A-Z][a-z]+ing\b[^.\n]{0,60},",
     "nominalisation": r"(?i)\bthe \w+(?:tion|sion|ment|ance|ence|ization|isation) of\b",
-    "linkedin_2026": r"(?i)\b(quietly|compound(s|ing)?|(a|the) signal|the work|built different|load-bearing|doing the heavy lifting)\b|(?m)^\w+ matters\.$",
+    "linkedin_2026": r"(?i)\b(quietly|compound(s|ing)?|(a|the) signal|the work|built different|load-bearing|doing the heavy lifting)\b",
+    "linkedin_2026_matters": r"(?im)^\w+ matters\.$",
     "decaying_2024": r"(?i)\b(delve|delving|tapestry|realm|intricate|journey|paradigm)\b",
 }
 
@@ -176,6 +177,12 @@ assert re.search(DENSITY_PATTERNS["vocab_verbs"], "We harnessed cross-functional
 assert re.search(DENSITY_PATTERNS["vocab_verbs"], "We fostered alignment.")
 assert re.search(DENSITY_PATTERNS["vocab_verbs"], "We unlocked 47% gains.")
 assert re.search(DENSITY_PATTERNS["ing_opener"], "Leveraging our data, we cut churn.")
+assert re.search(DENSITY_PATTERNS["linkedin_2026"], "The work quietly compounds.")
+assert re.search(DENSITY_PATTERNS["linkedin_2026_matters"], "Consistency matters.")
+# Inline (?i)/(?m) flags are only legal at position 0 from Python 3.11 on; a mid-pattern
+# flag raises re.error at import and takes the whole audit down before it scores anything.
+for _name, _pat in {**DENSITY_PATTERNS, **AI_PATTERNS}.items():
+    re.compile(_pat)
 assert re.search(AI_PATTERNS["closer_filler"], "What are your thoughts?")
 assert re.search(AI_PATTERNS["closer_filler"], "What's your take?")
 assert re.search(AI_PATTERNS["reveal_bridge"], "The result? We doubled.")

--- a/skills/linkedin-humanizer/references/audit-ai-tells.md
+++ b/skills/linkedin-humanizer/references/audit-ai-tells.md
@@ -132,7 +132,8 @@ DENSITY_PATTERNS = {
     "adverb_filler": r"(?i)\b(fundamentally|essentially|ultimately|arguably|certainly|definitely|undoubtedly)\b",
     "ing_opener": r"(?m)^[\s>*\-]*[A-Z][a-z]+ing\b[^.\n]{0,60},",
     "nominalisation": r"(?i)\bthe \w+(?:tion|sion|ment|ance|ence|ization|isation) of\b",
-    "linkedin_2026": r"(?i)\b(quietly|compound(s|ing)?|(a|the) signal|the work|built different|load-bearing|doing the heavy lifting)\b|(?m)^\w+ matters\.$",
+    "linkedin_2026": r"(?i)\b(quietly|compound(s|ing)?|(a|the) signal|the work|built different|load-bearing|doing the heavy lifting)\b",
+    "linkedin_2026_matters": r"(?im)^\w+ matters\.$",
     "decaying_2024": r"(?i)\b(delve|delving|tapestry|realm|intricate|journey|paradigm)\b",
 }
 
@@ -176,6 +177,12 @@ assert re.search(DENSITY_PATTERNS["vocab_verbs"], "We harnessed cross-functional
 assert re.search(DENSITY_PATTERNS["vocab_verbs"], "We fostered alignment.")
 assert re.search(DENSITY_PATTERNS["vocab_verbs"], "We unlocked 47% gains.")
 assert re.search(DENSITY_PATTERNS["ing_opener"], "Leveraging our data, we cut churn.")
+assert re.search(DENSITY_PATTERNS["linkedin_2026"], "The work quietly compounds.")
+assert re.search(DENSITY_PATTERNS["linkedin_2026_matters"], "Consistency matters.")
+# Inline (?i)/(?m) flags are only legal at position 0 from Python 3.11 on; a mid-pattern
+# flag raises re.error at import and takes the whole audit down before it scores anything.
+for _name, _pat in {**DENSITY_PATTERNS, **AI_PATTERNS}.items():
+    re.compile(_pat)
 assert re.search(AI_PATTERNS["closer_filler"], "What are your thoughts?")
 assert re.search(AI_PATTERNS["closer_filler"], "What's your take?")
 assert re.search(AI_PATTERNS["reveal_bridge"], "The result? We doubled.")


### PR DESCRIPTION
## The bug

`DENSITY_PATTERNS["linkedin_2026"]` in `skills/linkedin-humanizer/references/audit-ai-tells.md` has an inline `(?m)` flag in the middle of the alternation:

```python
"linkedin_2026": r"(?i)\b(quietly|compound(s|ing)?|...)\b|(?m)^\w+ matters\.$",
#                                                        ^^^^ position 112
```

[Python 3.11](https://docs.python.org/3/whatsnew/3.11.html#re) made a global inline flag anywhere but position 0 a hard `re.error`. So:

```
re.error: global flags not at the start of the expression at position 112
```

## Why it went unnoticed

The dict builds fine — patterns are just strings until compiled. The error only fires when the audit actually *scores* something, and `paragraph_density()` iterates every entry in `DENSITY_PATTERNS`, so it raises on the first paragraph of the first run. The existing sanity block never touches `linkedin_2026`, so it passes while the pattern is broken.

Net effect: on Python 3.11+, audit mode raises before scoring a single paragraph for anyone executing the reference block, and the `X matters.` check has probably never fired.

## The fix

Split the alternation into two entries, preserving both behaviours and matching how the rest of the dict is structured (one marker class per key):

```python
"linkedin_2026":         r"(?i)\b(quietly|compound(s|ing)?|...)\b",
"linkedin_2026_matters": r"(?im)^\w+ matters\.$",
```

Both still count as separate markers toward paragraph density, so scoring is unchanged apart from now actually running.

## Guard against regression

Added to the existing compile-time sanity block:

```python
assert re.search(DENSITY_PATTERNS["linkedin_2026"], "The work quietly compounds.")
assert re.search(DENSITY_PATTERNS["linkedin_2026_matters"], "Consistency matters.")
# Inline (?i)/(?m) flags are only legal at position 0 from Python 3.11 on; a mid-pattern
# flag raises re.error at import and takes the whole audit down before it scores anything.
for _name, _pat in {**DENSITY_PATTERNS, **AI_PATTERNS}.items():
    re.compile(_pat)
```

The loop makes a reintroduced mid-pattern flag fail loudly at the sanity check instead of silently at scoring time. It was the only such literal in the tree — I scanned every `r"..."` in all `.md` and `.py` files and this was the sole non-compiling one.

## Verification

Executing the reference block on Python 3.12.3:

| | `paragraph_density("The work quietly compounds.")` |
|---|---|
| before | `re.error: global flags not at the start of the expression at position 112` |
| after | `3` (correctly flags `the work`, `quietly`, `compounds` — hits the rewrite threshold) |

All pre-existing assertions still pass.

## Scope

Two files, same change — the main tree and the `.codex-marketplace/` mirror, which carries an identical copy.

---

Found while running `--mode audit` on a LinkedIn About draft. Genuinely useful skill; the vocabulary density scoring caught three 2026-layer markers I'd written without noticing.